### PR TITLE
prod: auto-clean when container existed

### DIFF
--- a/prod-server.sh
+++ b/prod-server.sh
@@ -116,7 +116,12 @@ function up {
     command pull ; assertSuccess
 
     echo "Starting the server..."
-    command up -d ; assertSuccess
+    command up -d |& grep "is already in use by container"
+    if [[ $? -eq 0 ]] ; then # Container conflict, perform clean and try again.
+        clean
+        echo "Starting the server after a clean..."
+        command up -d ; assertSuccess
+    fi
 
     echo -e "${GREEN}Server is running.${ENDCOLOR}"
 }


### PR DESCRIPTION
Fixes the error 

> Error response from daemon: Conflict. The container name "/biab-runner-julia" is already in use by container "5c4febf601ca15d0b7f48414a42a4762aaf04356ac2a645d7c3cfbf70761dca9". You have to remove (or rename) that container to be able to reuse that name.

when running server-up.sh