### PR TITLE
37 warning messages

### DIFF
--- a/ui/src/Layout.js
+++ b/ui/src/Layout.js
@@ -21,14 +21,14 @@ export function Layout(props) {
   }, [windowHeight])
 
   const location = useLocation();
-  const hasChanged = props.hasChanged;
 
   const handleNavLinkClick = (event) => {
-    if (location.pathname == '/pipeline-editor' && hasChanged) {
-      const confirmNavigation = window.confirm("Reload site? Changes you made may not be saved.");
+    console.log(event)
+    if (location.pathname == '/pipeline-editor' && props.hasUnsavedChanges) {
+      const confirmNavigation = window.confirm("Leaving the editor: any unsaved changes will be lost.");
       if (!confirmNavigation) {
         event.preventDefault();
-      } 
+      }
     }
   };
 
@@ -52,7 +52,7 @@ export function Layout(props) {
           <NavLink to="/versions" onClick={handleNavLinkClick}>Server info</NavLink>
         </nav>
 
-        {props.popupContent && 
+        {props.popupContent &&
           <div className='fullScreenPopup'>
             <div className='content'>
               {props.popupContent}

--- a/ui/src/Layout.js
+++ b/ui/src/Layout.js
@@ -1,8 +1,6 @@
 import './Layout.css';
 
-import { Button, Dialog, DialogTitle, DialogActions, DialogContent, DialogContentText } from '@mui/material';
-
-import React, { useEffect, useState, useCallback } from 'react'
+import React, { useEffect, useState } from 'react'
 
 import { NavLink } from "react-router-dom";
 
@@ -10,40 +8,15 @@ import BiaBLogo from "./img/boninabox.jpg"
 
 import useWindowDimensions from "./utils/WindowDimensions"
 
-import { useLocation, useNavigate } from "react-router-dom";
-
 export function Layout(props) {
   const { windowHeight } = useWindowDimensions();
   const [mainHeight, setMainHeight] = useState();
-  const [modal, setModal] = useState(null);
-  const [nextLocation, setNextLocation] = useState(null);
-
-  const hideModal = useCallback((modalName) => {
-    setModal(currentModal => currentModal === modalName ? null : currentModal)
-  }, [setModal])
 
   // Main section size
   useEffect(() => {
     let nav = document.getElementsByTagName('nav')[0];
     setMainHeight(windowHeight - nav.offsetHeight)
   }, [windowHeight])
-
-  const location = useLocation();
-  const navigate = useNavigate();
-
-  const handleNavLinkClick = (event, to) => {
-    if (location.pathname === '/pipeline-editor' && props.hasUnsavedChanges) {
-      event.preventDefault();
-      setModal("leavePage");
-      setNextLocation(to);
-    }
-  };
-
-  const navigateToNextLocation = () => {
-    navigate(nextLocation);
-    setNextLocation(null);
-    hideModal('leavePage');
-  }
 
   return (
     <>
@@ -56,13 +29,13 @@ export function Layout(props) {
 
       <div className='right-content'>
         <nav>
-          <NavLink to="/script-form" onClick={(event) => handleNavLinkClick(event, "/script-form")}>Single script run</NavLink>
+          <NavLink to="/script-form">Single script run</NavLink>
           &nbsp;|&nbsp;
-          <NavLink to="/pipeline-form" onClick={(event) => handleNavLinkClick(event, "/pipeline-form")}>Pipeline run</NavLink>
+          <NavLink to="/pipeline-form">Pipeline run</NavLink>
           &nbsp;|&nbsp;
           <NavLink to="/pipeline-editor">Pipeline editor</NavLink>
           &nbsp;|&nbsp;
-          <NavLink to="/versions" onClick={(event) => handleNavLinkClick(event, "/versions")}>Server info</NavLink>
+          <NavLink to="/versions">Server info</NavLink>
         </nav>
 
         {props.popupContent &&
@@ -78,22 +51,6 @@ export function Layout(props) {
           {props.right}
         </main>
       </div>
-
-      <Dialog
-        open={modal === 'leavePage'}
-        onClose={() => hideModal('leavePage')}
-      >
-        <DialogTitle>Leave Page?</DialogTitle>
-        <DialogContent>
-          <DialogContentText>
-            Changes you made may not be saved.
-          </DialogContentText>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={() => hideModal('leavePage')}>Stay</Button>
-          <Button onClick={navigateToNextLocation}>Leave</Button>
-        </DialogActions>
-      </Dialog>
     </>
   );
 }

--- a/ui/src/Layout.js
+++ b/ui/src/Layout.js
@@ -23,7 +23,6 @@ export function Layout(props) {
   const location = useLocation();
 
   const handleNavLinkClick = (event) => {
-    console.log(event)
     if (location.pathname === '/pipeline-editor' && props.hasUnsavedChanges) {
       const confirmNavigation = window.confirm("Leaving the editor: any unsaved changes will be lost.");
       if (!confirmNavigation) {

--- a/ui/src/Layout.js
+++ b/ui/src/Layout.js
@@ -28,7 +28,6 @@ export function Layout(props) {
       const confirmNavigation = window.confirm("Reload site? Changes you made may not be saved.");
       if (!confirmNavigation) {
         event.preventDefault();
-        return;
       } 
     }
   };

--- a/ui/src/Layout.js
+++ b/ui/src/Layout.js
@@ -8,7 +8,7 @@ import BiaBLogo from "./img/boninabox.jpg"
 
 import useWindowDimensions from "./utils/WindowDimensions"
 
-import { useLocation, useNavigate } from "react-router-dom";
+import { useLocation } from "react-router-dom";
 
 export function Layout(props) {
   const { windowHeight } = useWindowDimensions();
@@ -21,7 +21,6 @@ export function Layout(props) {
   }, [windowHeight])
 
   const location = useLocation();
-  const navigate = useNavigate();
   const hasChanged = props.hasChanged;
 
   const handleNavLinkClick = (event) => {

--- a/ui/src/Layout.js
+++ b/ui/src/Layout.js
@@ -1,12 +1,16 @@
 import './Layout.css';
 
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useState, useContext } from 'react'
 
 import { NavLink } from "react-router-dom";
 
 import BiaBLogo from "./img/boninabox.jpg"
 
 import useWindowDimensions from "./utils/WindowDimensions"
+
+import { useLocation, useNavigate } from "react-router-dom";
+
+import NavigationContext from './NavigationContext';
 
 export function Layout(props) {
   const { windowHeight } = useWindowDimensions();
@@ -17,6 +21,25 @@ export function Layout(props) {
     let nav = document.getElementsByTagName('nav')[0];
     setMainHeight(windowHeight - nav.offsetHeight)
   }, [windowHeight])
+
+  const location = useLocation();
+  const navigate = useNavigate();
+  const { hasChanged, setHasChanged } = useContext(NavigationContext);
+
+  const handleNavLinkClick = (event, to) => {
+    if (location.pathname == '/pipeline-editor') {
+      if (hasChanged){
+        const confirmNavigation = window.confirm("Reload site? Changes you made may not be saved.");
+        if (!confirmNavigation) {
+          event.preventDefault(); // Prevent navigation if canceled
+        } else {
+          navigate(to);
+        }
+      } else {
+        navigate(to);
+      }
+    }
+  };
 
   return (
     <>
@@ -29,13 +52,13 @@ export function Layout(props) {
 
       <div className='right-content'>
         <nav>
-          <NavLink to="/script-form">Single script run</NavLink>
+          <NavLink to="/script-form" onClick={(event) => handleNavLinkClick(event, '/script-form')}>Single script run</NavLink>
           &nbsp;|&nbsp;
-          <NavLink to="/pipeline-form">Pipeline run</NavLink>
+          <NavLink to="/pipeline-form" onClick={(event) => handleNavLinkClick(event, '/pipeline-form')}>Pipeline run</NavLink>
           &nbsp;|&nbsp;
           <NavLink to="/pipeline-editor">Pipeline editor</NavLink>
           &nbsp;|&nbsp;
-          <NavLink to="/versions">Server info</NavLink>
+          <NavLink to="/versions" onClick={(event) => handleNavLinkClick(event, '/versions')}>Server info</NavLink>
         </nav>
 
         {props.popupContent && 

--- a/ui/src/Layout.js
+++ b/ui/src/Layout.js
@@ -1,6 +1,6 @@
 import './Layout.css';
 
-import React, { useEffect, useState, useContext } from 'react'
+import React, { useEffect, useState } from 'react'
 
 import { NavLink } from "react-router-dom";
 
@@ -9,8 +9,6 @@ import BiaBLogo from "./img/boninabox.jpg"
 import useWindowDimensions from "./utils/WindowDimensions"
 
 import { useLocation, useNavigate } from "react-router-dom";
-
-import NavigationContext from './NavigationContext';
 
 export function Layout(props) {
   const { windowHeight } = useWindowDimensions();
@@ -24,14 +22,14 @@ export function Layout(props) {
 
   const location = useLocation();
   const navigate = useNavigate();
-  const { hasChanged, setHasChanged } = useContext(NavigationContext);
+  const hasChanged = props.hasChanged;
 
   const handleNavLinkClick = (event, to) => {
     if (location.pathname == '/pipeline-editor') {
       if (hasChanged){
         const confirmNavigation = window.confirm("Reload site? Changes you made may not be saved.");
         if (!confirmNavigation) {
-          event.preventDefault(); // Prevent navigation if canceled
+          event.preventDefault();
         } else {
           navigate(to);
         }

--- a/ui/src/Layout.js
+++ b/ui/src/Layout.js
@@ -24,7 +24,7 @@ export function Layout(props) {
 
   const handleNavLinkClick = (event) => {
     console.log(event)
-    if (location.pathname == '/pipeline-editor' && props.hasUnsavedChanges) {
+    if (location.pathname === '/pipeline-editor' && props.hasUnsavedChanges) {
       const confirmNavigation = window.confirm("Leaving the editor: any unsaved changes will be lost.");
       if (!confirmNavigation) {
         event.preventDefault();

--- a/ui/src/Layout.js
+++ b/ui/src/Layout.js
@@ -24,18 +24,13 @@ export function Layout(props) {
   const navigate = useNavigate();
   const hasChanged = props.hasChanged;
 
-  const handleNavLinkClick = (event, to) => {
-    if (location.pathname == '/pipeline-editor') {
-      if (hasChanged){
-        const confirmNavigation = window.confirm("Reload site? Changes you made may not be saved.");
-        if (!confirmNavigation) {
-          event.preventDefault();
-        } else {
-          navigate(to);
-        }
-      } else {
-        navigate(to);
-      }
+  const handleNavLinkClick = (event) => {
+    if (location.pathname == '/pipeline-editor' && hasChanged) {
+      const confirmNavigation = window.confirm("Reload site? Changes you made may not be saved.");
+      if (!confirmNavigation) {
+        event.preventDefault();
+        return;
+      } 
     }
   };
 
@@ -50,13 +45,13 @@ export function Layout(props) {
 
       <div className='right-content'>
         <nav>
-          <NavLink to="/script-form" onClick={(event) => handleNavLinkClick(event, '/script-form')}>Single script run</NavLink>
+          <NavLink to="/script-form" onClick={handleNavLinkClick}>Single script run</NavLink>
           &nbsp;|&nbsp;
-          <NavLink to="/pipeline-form" onClick={(event) => handleNavLinkClick(event, '/pipeline-form')}>Pipeline run</NavLink>
+          <NavLink to="/pipeline-form" onClick={handleNavLinkClick}>Pipeline run</NavLink>
           &nbsp;|&nbsp;
           <NavLink to="/pipeline-editor">Pipeline editor</NavLink>
           &nbsp;|&nbsp;
-          <NavLink to="/versions" onClick={(event) => handleNavLinkClick(event, '/versions')}>Server info</NavLink>
+          <NavLink to="/versions" onClick={handleNavLinkClick}>Server info</NavLink>
         </nav>
 
         {props.popupContent && 

--- a/ui/src/NavigationContext.js
+++ b/ui/src/NavigationContext.js
@@ -1,0 +1,5 @@
+import {createContext} from 'react';
+
+const NavigationContext = createContext();
+
+export default NavigationContext;

--- a/ui/src/NavigationContext.js
+++ b/ui/src/NavigationContext.js
@@ -1,5 +1,0 @@
-import {createContext} from 'react';
-
-const NavigationContext = createContext();
-
-export default NavigationContext;

--- a/ui/src/components/PipelineEditor/PipelineEditor.js
+++ b/ui/src/components/PipelineEditor/PipelineEditor.js
@@ -786,7 +786,9 @@ export default function PipelineEditor(props) {
     if (reactFlowInstance != null) {
       localStorage.setItem("currentFileName", currentFileName);
     }
-  }, [currentFileName]);
+  }, [savedJSON]); 
+  //savedJSON and not currentFileName since pipeline could be loaded from file which sets a currentFileName but no pipeline is saved to the server
+  //this will cause an error when user reloads page and the app tries to restore previous unsaved pipeline
 
   const onLoadFlow = useCallback(async (flow) => {
     if (flow) {

--- a/ui/src/components/PipelineEditor/PipelineEditor.js
+++ b/ui/src/components/PipelineEditor/PipelineEditor.js
@@ -944,7 +944,7 @@ export default function PipelineEditor(props) {
     setSavedJSON(null);
   }, [setEditSession, setCurrentFileName, setNodes, setEdges, hideModal])
 
-  //useCallback so react memorizes that it's the same function when beforeunload event listener is added and removed
+  //useCallback with empty dependencies so that addEventListener and removeEventListener only work on this one function only created once
   const handleBeforeUnload = useCallback((event) => {
     event.preventDefault();
     event.returnValue = '';

--- a/ui/src/components/PipelineEditor/PipelineEditor.js
+++ b/ui/src/components/PipelineEditor/PipelineEditor.js
@@ -937,13 +937,19 @@ export default function PipelineEditor(props) {
     event.preventDefault();
     event.returnValue = '';
   }, []);
+  const handlePopstate = useCallback((event) => {
+    event.preventDefault();
+    event.returnValue = '';
+  }, []);
 
   useEffect(() => {
     if (hasUnsavedChanges && ((savedJSON === null && nodes.length === 0) || (savedJSON !== null && savedJSON === generateSaveJSON()))) {
       window.removeEventListener('beforeunload', handleBeforeUnload);
+      window.removeEventListener('popstate', handlePopstate);
       setUnsavedChanges(false);
     } else if (!hasUnsavedChanges && ((savedJSON === null && nodes.length !== 0) || (savedJSON !== null && savedJSON !== generateSaveJSON()))) {
       window.addEventListener('beforeunload', handleBeforeUnload);
+      window.addEventListener('popstate', handlePopstate);
       setUnsavedChanges(true);
     }
   }, [nodes, edges, savedJSON, handleBeforeUnload]);
@@ -954,6 +960,13 @@ export default function PipelineEditor(props) {
       window.removeEventListener('beforeunload', handleBeforeUnload); //so that this event listener doesn't persist when the component unmounts (e.g. React Router change)
     };
   }, [handleBeforeUnload])
+
+  //removes event listener when PipelineEditor component unmounts
+  useEffect(() => {
+    return () => {
+      window.removeEventListener('popstate', handlePopstate);
+    };
+  }, [handlePopstate])
 
   return (
     <div id="editorLayout">

--- a/ui/src/components/PipelineEditor/PipelineEditor.js
+++ b/ui/src/components/PipelineEditor/PipelineEditor.js
@@ -727,8 +727,8 @@ export default function PipelineEditor(props) {
                 )
               } else {
                 setCurrentFileName(descriptionFile);
-                onLoadFlow(data);
                 setSavedJSON(JSON.stringify(data, null, 2));
+                onLoadFlow(data);
               }
             });
           })
@@ -748,8 +748,8 @@ export default function PipelineEditor(props) {
         )
       } else {
         setCurrentFileName(descriptionFile);
-        onLoadFlow(data);
         setSavedJSON(JSON.stringify(data, null, 2));
+        onLoadFlow(data);
       }
     });
   };
@@ -937,8 +937,19 @@ export default function PipelineEditor(props) {
         window.removeEventListener('beforeunload', handleBeforeUnload);
         setBeforeUnloadEventListener(false);
       }
+    } else if (currentFileName !== null && currentFileName !== '') {
+      if (!beforeUnloadEventListener) {
+        window.addEventListener('beforeunload', handleBeforeUnload);
+        setBeforeUnloadEventListener(true);
+      }
+    }
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload); //so that this event listener doesn't persist when the component unmounts (e.g. React Router change)
+    };
+  }, [nodes.length, edges.length]);
 
-    } else if (savedJSON !== null) {
+  useEffect(()=> {
+    if (savedJSON !== null) {
       if (savedJSON === generateSaveJSON()) {
         if (beforeUnloadEventListener) {
           window.removeEventListener('beforeunload', handleBeforeUnload);
@@ -954,7 +965,7 @@ export default function PipelineEditor(props) {
     return () => {
       window.removeEventListener('beforeunload', handleBeforeUnload); //so that this event listener doesn't persist when the component unmounts (e.g. React Router change)
     };
-  }, [nodes.length, edges.length, savedJSON]); //nodes.length and edges.length can be the same for a unnamed pipeline that a user is editing and a pipeline already saved to the server
+  }, [savedJSON]);
 
   return (
     <div id="editorLayout">
@@ -1098,6 +1109,8 @@ export default function PipelineEditor(props) {
                     <button id="clear" disabled={nodes.length === 0} onClick={() => setModal('clear')}>Clear</button>
                     <button id="saveBtn" onClick={() => { if (currentFileName) onSave(currentFileName); else setModal('saveAs') }}>Save</button>
                     <button id="saveAsBtn" onClick={() => setModal('saveAs')}>Save As...</button>
+                    <button id="generate" onClick={() => console.log(generateSaveJSON()===savedJSON)}>Generate</button>
+                    <button id="savedJSON" onClick={() => console.log(savedJSON)}>SavedJSON</button>
                   </>
                 }
               </div>

--- a/ui/src/components/PipelineEditor/PipelineEditor.js
+++ b/ui/src/components/PipelineEditor/PipelineEditor.js
@@ -645,11 +645,11 @@ export default function PipelineEditor(props) {
 
   const onSave = useCallback((fileName) => {
     if (reactFlowInstance) {
-
+      let saveJSON = generateSaveJSON();
       if (fileName) {
         let fileNameWithoutExtension = fileName.endsWith(".json") ? fileName.slice(0, -5) : fileName;
         fileNameWithoutExtension = fileNameWithoutExtension.replaceAll("/", ">")
-        api.savePipeline(fileNameWithoutExtension, generateSaveJSON(), (error, data, response) => {
+        api.savePipeline(fileNameWithoutExtension, saveJSON, (error, data, response) => {
           if (error) {
             showAlert(
               'error',
@@ -661,14 +661,14 @@ export default function PipelineEditor(props) {
             showAlert('warning', 'Pipeline saved with errors', response.text)
 
           } else {
-            setSavedJSON(generateSaveJSON());
+            setSavedJSON(saveJSON);
             setModal('saveSuccess');
           }
         });
 
       } else {
         navigator.clipboard
-          .writeText(generateSaveJSON())
+          .writeText(saveJSON)
           .then(() => {
             showAlert('info', 'Pipeline content copied to clipboard',
               'Use git to add the code to the BON in a Box repository.'
@@ -933,6 +933,9 @@ export default function PipelineEditor(props) {
   }, []);
 
   useEffect(() => {
+    //console.log(nodes.length, edges.length, savedJSON ? savedJSON === generateSaveJSON(): "");
+    //console.log(savedJSON ? savedJSON : "");
+    //console.log(reactFlowInstance ? generateSaveJSON() : "");
     if (savedJSON === null) {
       if (nodes.length === 0) {
         if (beforeUnloadEventListener) {
@@ -958,7 +961,7 @@ export default function PipelineEditor(props) {
         }
       }
     }
-  }, [nodes.length, edges.length, savedJSON]);
+  }, [nodes, edges, savedJSON]);
 
   useEffect(() => {
     return () => {
@@ -1108,6 +1111,9 @@ export default function PipelineEditor(props) {
                     <button id="clear" disabled={nodes.length === 0} onClick={() => setModal('clear')}>Clear</button>
                     <button id="saveBtn" onClick={() => { if (currentFileName) onSave(currentFileName); else setModal('saveAs') }}>Save</button>
                     <button id="saveAsBtn" onClick={() => setModal('saveAs')}>Save As...</button>
+                    <button id="savedJSON" onClick={() => console.log(savedJSON)}>savedJSON</button>
+                    <button id="generate" onClick={() => console.log(generateSaveJSON())}>generateSaveJSON</button>
+                    <button id="compare" onClick={() => console.log(savedJSON === generateSaveJSON())}>Compare</button>
                   </>
                 }
               </div>

--- a/ui/src/components/PipelineEditor/PipelineEditor.js
+++ b/ui/src/components/PipelineEditor/PipelineEditor.js
@@ -760,6 +760,7 @@ export default function PipelineEditor(props) {
   const onLoadFromLocalStorage = (descriptionFile) => {
     api.getPipeline(descriptionFile, (error, data, response) => {
       if (error) {
+        localStorage.setItem("currentFileName", '');
         showAlert(
           'error',
           'Error loading the pipeline',

--- a/ui/src/components/PipelineEditor/PipelineEditor.js
+++ b/ui/src/components/PipelineEditor/PipelineEditor.js
@@ -784,11 +784,13 @@ export default function PipelineEditor(props) {
 
   useEffect(()=> {
     if (reactFlowInstance != null) {
-      localStorage.setItem("currentFileName", currentFileName);
+      if (savedJSON !== null) { //when pipeline is loaded from file, it's not automatically saved to the server, but currentFileName is still set
+        localStorage.setItem("currentFileName", currentFileName);
+      } else {
+        localStorage.setItem("currentFileName", '');
+      }
     }
   }, [savedJSON]); 
-  //savedJSON and not currentFileName since pipeline could be loaded from file which sets a currentFileName but no pipeline is saved to the server
-  //this will cause an error when user reloads page and the app tries to restore previous unsaved pipeline
 
   const onLoadFlow = useCallback(async (flow) => {
     if (flow) {

--- a/ui/src/components/PipelineEditor/PipelineEditor.js
+++ b/ui/src/components/PipelineEditor/PipelineEditor.js
@@ -3,7 +3,7 @@ import "react-flow-renderer/dist/theme-default.css";
 import "./Editor.css";
 import { TextField, Button, Dialog, DialogTitle, DialogContent, DialogActions, Alert, AlertTitle, Snackbar, DialogContentText } from '@mui/material';
 
-import React, { useState, useRef, useCallback, useEffect, useContext } from "react";
+import React, { useState, useRef, useCallback, useEffect } from "react";
 import ReactFlow, {
   ReactFlowProvider,
   addEdge,
@@ -37,7 +37,6 @@ import {
 import sleep from "../../utils/Sleep";
 import { IOListPane } from "./IOListPane";
 import { MetadataPane } from "./MetadataPane";
-import NavigationContext from "../../NavigationContext";
 
 const yaml = require('js-yaml');
 const _lang = require('lodash/lang');
@@ -82,7 +81,8 @@ export default function PipelineEditor(props) {
   const [metadata, setMetadata] = useState("");
   const [currentFileName, setCurrentFileName] = useState("");
   const [savedJSON, setSavedJSON] = useState(null);
-  const { hasChanged, setHasChanged } = useContext(NavigationContext);
+  const hasChanged = props.hasChanged;
+  const setHasChanged = props.setHasChanged;
 
   const [editSession, setEditSession] = useState(Math.random());
 

--- a/ui/src/components/PipelineEditor/PipelineEditor.js
+++ b/ui/src/components/PipelineEditor/PipelineEditor.js
@@ -696,6 +696,7 @@ export default function PipelineEditor(props) {
       }
 
       setCurrentFileName(file.name);
+      setSavedJSON = null;
       // Now that it's done, reset the value of the input file.
       inputFile.current.value = "";
     }
@@ -932,15 +933,17 @@ export default function PipelineEditor(props) {
   }, []);
 
   useEffect(()=> {
-    if (nodes.length === 0) {
-      if (beforeUnloadEventListener) {
-        window.removeEventListener('beforeunload', handleBeforeUnload);
-        setBeforeUnloadEventListener(false);
-      }
-    } else if (currentFileName !== null && currentFileName !== '') {
-      if (!beforeUnloadEventListener) {
-        window.addEventListener('beforeunload', handleBeforeUnload);
-        setBeforeUnloadEventListener(true);
+    if (savedJSON === null) {
+      if (nodes.length === 0) {
+        if (beforeUnloadEventListener) {
+          window.removeEventListener('beforeunload', handleBeforeUnload);
+          setBeforeUnloadEventListener(false);
+        }
+      } else {
+        if (!beforeUnloadEventListener) {
+          window.addEventListener('beforeunload', handleBeforeUnload);
+          setBeforeUnloadEventListener(true);
+        }
       }
     }
     return () => {
@@ -965,7 +968,7 @@ export default function PipelineEditor(props) {
     return () => {
       window.removeEventListener('beforeunload', handleBeforeUnload); //so that this event listener doesn't persist when the component unmounts (e.g. React Router change)
     };
-  }, [savedJSON]);
+  }, [savedJSON, nodes.length, edges.length]);
 
   return (
     <div id="editorLayout">
@@ -1109,8 +1112,6 @@ export default function PipelineEditor(props) {
                     <button id="clear" disabled={nodes.length === 0} onClick={() => setModal('clear')}>Clear</button>
                     <button id="saveBtn" onClick={() => { if (currentFileName) onSave(currentFileName); else setModal('saveAs') }}>Save</button>
                     <button id="saveAsBtn" onClick={() => setModal('saveAs')}>Save As...</button>
-                    <button id="generate" onClick={() => console.log(generateSaveJSON()===savedJSON)}>Generate</button>
-                    <button id="savedJSON" onClick={() => console.log(savedJSON)}>SavedJSON</button>
                   </>
                 }
               </div>

--- a/ui/src/components/PipelineEditor/PipelineEditor.js
+++ b/ui/src/components/PipelineEditor/PipelineEditor.js
@@ -951,30 +951,12 @@ export default function PipelineEditor(props) {
   }, []);
 
   useEffect(() => {
-    if (savedJSON === null) {
-      if (nodes.length === 0) {
-        if (hasChanged) {
-          window.removeEventListener('beforeunload', handleBeforeUnload);
-          setHasChanged(false);
-        }
-      } else {
-        if (!hasChanged) {
-          window.addEventListener('beforeunload', handleBeforeUnload);
-          setHasChanged(true);
-        }
-      }
-    } else {
-      if (savedJSON === generateSaveJSON()) {
-        if (hasChanged) {
-          window.removeEventListener('beforeunload', handleBeforeUnload);
-          setHasChanged(false);
-        }
-      } else {
-        if (!hasChanged) {
-          window.addEventListener('beforeunload', handleBeforeUnload);
-          setHasChanged(true);
-        }
-      }
+    if (hasChanged && ((savedJSON === null && nodes.length === 0) || (savedJSON !== null && savedJSON === generateSaveJSON()))) {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+      setHasChanged(false);
+    } else if (!hasChanged && ((savedJSON === null && nodes.length !== 0) || (savedJSON !== null && savedJSON !== generateSaveJSON()))) {
+      window.addEventListener('beforeunload', handleBeforeUnload);
+      setHasChanged(true);
     }
   }, [nodes, edges, savedJSON]);
 

--- a/ui/src/components/PipelineEditor/PipelineEditor.js
+++ b/ui/src/components/PipelineEditor/PipelineEditor.js
@@ -729,6 +729,35 @@ export default function PipelineEditor(props) {
     });
   };
 
+  const onLoadFromLocalStorage = (descriptionFile) => {
+    api.getPipeline(descriptionFile, (error, data, response) => {
+      if (error) {
+        showAlert(
+          'error',
+          'Error loading the pipeline',
+          (response && response.text) ? response.text : error.toString()
+        )
+      } else {
+        setCurrentFileName(descriptionFile);
+        onLoadFlow(data);
+      }
+    });
+  };
+
+  useEffect(()=> {
+    if(localStorage.getItem("currentFileName")){
+      if (reactFlowInstance != null) {
+        onLoadFromLocalStorage(localStorage.getItem("currentFileName"));
+      }
+    }
+  }, [reactFlowInstance]);
+
+  useEffect(()=> {
+    if (reactFlowInstance != null) {
+      localStorage.setItem("currentFileName", currentFileName);
+    }
+  }, [currentFileName]);
+
   const onLoadFlow = useCallback(async (flow) => {
     if (flow) {
       setEditSession(Math.random())
@@ -884,11 +913,12 @@ export default function PipelineEditor(props) {
     hideModal('clear');
   }, [setEditSession, setCurrentFileName, setNodes, setEdges, hideModal])
 
+
+  //this adds it forever even when you switch pages
   const handleBeforeUnload = function(event) {
     event.preventDefault();
   }
-  
-  document.addEventListener("beforeunload", handleBeforeUnload);
+  window.addEventListener("beforeunload", handleBeforeUnload);
 
   return (
     <div id="editorLayout">

--- a/ui/src/components/PipelineEditor/PipelineEditor.js
+++ b/ui/src/components/PipelineEditor/PipelineEditor.js
@@ -1128,8 +1128,8 @@ export default function PipelineEditor(props) {
                   ? <button id="saveBtn" onClick={() => onSave()}>Save to clipboard</button>
                   : <>
                     <button id="clear" disabled={nodes.length === 0} onClick={() => setModal('clear')}>Clear</button>
-                    <button id="saveBtn" onClick={() => { if (currentFileName) onSave(currentFileName); else setModal('saveAs') }}>Save</button>
-                    <button id="saveAsBtn" onClick={() => setModal('saveAs')}>Save As...</button>
+                    <button id="saveBtn" disabled={!hasUnsavedChanges} onClick={() => { if (currentFileName) onSave(currentFileName); else setModal('saveAs') }}>Save</button>
+                    <button id="saveAsBtn" disabled={!hasUnsavedChanges} onClick={() => setModal('saveAs')}>Save As...</button>
                   </>
                 }
               </div>

--- a/ui/src/components/PipelineEditor/PipelineEditor.js
+++ b/ui/src/components/PipelineEditor/PipelineEditor.js
@@ -933,9 +933,6 @@ export default function PipelineEditor(props) {
   }, []);
 
   useEffect(() => {
-    //console.log(nodes.length, edges.length, savedJSON ? savedJSON === generateSaveJSON(): "");
-    //console.log(savedJSON ? savedJSON : "");
-    //console.log(reactFlowInstance ? generateSaveJSON() : "");
     if (savedJSON === null) {
       if (nodes.length === 0) {
         if (beforeUnloadEventListener) {
@@ -1111,9 +1108,6 @@ export default function PipelineEditor(props) {
                     <button id="clear" disabled={nodes.length === 0} onClick={() => setModal('clear')}>Clear</button>
                     <button id="saveBtn" onClick={() => { if (currentFileName) onSave(currentFileName); else setModal('saveAs') }}>Save</button>
                     <button id="saveAsBtn" onClick={() => setModal('saveAs')}>Save As...</button>
-                    <button id="savedJSON" onClick={() => console.log(savedJSON)}>savedJSON</button>
-                    <button id="generate" onClick={() => console.log(generateSaveJSON())}>generateSaveJSON</button>
-                    <button id="compare" onClick={() => console.log(savedJSON === generateSaveJSON())}>Compare</button>
                   </>
                 }
               </div>

--- a/ui/src/components/PipelineEditor/PipelineEditor.js
+++ b/ui/src/components/PipelineEditor/PipelineEditor.js
@@ -666,6 +666,7 @@ export default function PipelineEditor(props) {
             showAlert('warning', 'Pipeline saved with errors', response.text)
 
           } else {
+            localStorage.setItem("currentFileName", fileName);
             setSavedJSON(saveJSON);
             setModal('saveSuccess');
           }
@@ -704,7 +705,8 @@ export default function PipelineEditor(props) {
       setCurrentFileName(file.name);
 
       // TODO: Use loaded JSON and test
-      setSavedJSON(null);
+      setSavedJSON(null); //this file is not saved on the server
+      localStorage.setItem("currentFileName", '');
       // Now that it's done, reset the value of the input file.
       inputFile.current.value = "";
     }
@@ -736,6 +738,7 @@ export default function PipelineEditor(props) {
                 )
               } else {
                 setCurrentFileName(descriptionFile);
+                localStorage.setItem("currentFileName", descriptionFile);
                 setSavedJSON(JSON.stringify(data, null, 2));
                 onLoadFlow(data);
               }
@@ -758,6 +761,7 @@ export default function PipelineEditor(props) {
         )
       } else {
         setCurrentFileName(descriptionFile);
+        localStorage.setItem("currentFileName", descriptionFile);
         setSavedJSON(JSON.stringify(data, null, 2));
         onLoadFlow(data);
       }
@@ -771,22 +775,6 @@ export default function PipelineEditor(props) {
         onLoadFromLocalStorage(localStorage.getItem("currentFileName"));
     }
   }, [reactFlowInstance]);
-
-  /**
-    * saveJSON instead of currentFileName in dependencies: after a pipeline is loaded from a file, when it is saved,
-    * savedJSON changes but currentFileName doesn't and localStorage should be updated in this specific case.
-    * currentFileName should be added to these dependencies for a case where two different server files are identical
-    * except for their file names, but this seems redundant and inefficient for most cases.
-    */
-  useEffect(()=> {
-    if (reactFlowInstance != null) {
-      if (savedJSON !== null) { //when pipeline is loaded from file, it's not automatically saved to the server, but currentFileName is still set
-        localStorage.setItem("currentFileName", currentFileName);
-      } else {
-        localStorage.setItem("currentFileName", '');
-      }
-    }
-  }, [savedJSON]);
 
   const onLoadFlow = useCallback(async (flow) => {
     if (flow) {

--- a/ui/src/components/PipelineEditor/PipelineEditor.js
+++ b/ui/src/components/PipelineEditor/PipelineEditor.js
@@ -70,6 +70,10 @@ document.addEventListener('keydown', e => {
   }
 });
 
+document.addEventListener("beforeunload", function(event) {
+  event.preventDefault();
+});
+
 export default function PipelineEditor(props) {
   const reactFlowWrapper = useRef(null);
   const [nodes, setNodes, onNodesChange] = useNodesState([]);

--- a/ui/src/components/PipelineEditor/PipelineEditor.js
+++ b/ui/src/components/PipelineEditor/PipelineEditor.js
@@ -1128,8 +1128,8 @@ export default function PipelineEditor(props) {
                   ? <button id="saveBtn" onClick={() => onSave()}>Save to clipboard</button>
                   : <>
                     <button id="clear" disabled={nodes.length === 0} onClick={() => setModal('clear')}>Clear</button>
-                    <button id="saveBtn" disabled={!hasUnsavedChanges} onClick={() => { if (currentFileName) onSave(currentFileName); else setModal('saveAs') }}>Save</button>
-                    <button id="saveAsBtn" disabled={!hasUnsavedChanges} onClick={() => setModal('saveAs')}>Save As...</button>
+                    <button id="saveBtn" onClick={() => { if (currentFileName) onSave(currentFileName); else setModal('saveAs') }}>Save</button>
+                    <button id="saveAsBtn" onClick={() => setModal('saveAs')}>Save As...</button>
                   </>
                 }
               </div>

--- a/ui/src/components/PipelineEditor/PipelineEditor.js
+++ b/ui/src/components/PipelineEditor/PipelineEditor.js
@@ -697,7 +697,7 @@ export default function PipelineEditor(props) {
       }
 
       setCurrentFileName(file.name);
-      setSavedJSON = null;
+      setSavedJSON(null);
       // Now that it's done, reset the value of the input file.
       inputFile.current.value = "";
     }

--- a/ui/src/components/PipelineEditor/PipelineEditor.js
+++ b/ui/src/components/PipelineEditor/PipelineEditor.js
@@ -703,6 +703,23 @@ export default function PipelineEditor(props) {
     }
   };
 
+  //when loading pipeline from the server, the data has no weights or different weights compared to the output of generateSaveJSON()
+  //this function does exactly what generateSaveJSON does to add weights, so that savedJSON and generateSaveJSON() can be compared to detect changes
+  const prepareServerData = (data) => {
+    let dataCopy = _lang.cloneDeep(data);
+    let i = 0;
+    for (let key in dataCopy.inputs){
+      dataCopy.inputs[key].weight = i;
+      i++;
+    }
+    let j = 0;
+    for (let key in dataCopy.outputs){
+      dataCopy.outputs[key].weight = j;
+      j++
+    }
+    return dataCopy;
+  };
+
   const onLoadFromServerBtnClick = (event) => {
     event.stopPropagation();
     event.preventDefault();
@@ -729,7 +746,7 @@ export default function PipelineEditor(props) {
                 )
               } else {
                 setCurrentFileName(descriptionFile);
-                setSavedJSON(JSON.stringify(data, null, 2));
+                setSavedJSON(JSON.stringify(prepareServerData(data), null, 2));
                 onLoadFlow(data);
               }
             });
@@ -750,7 +767,7 @@ export default function PipelineEditor(props) {
         )
       } else {
         setCurrentFileName(descriptionFile);
-        setSavedJSON(JSON.stringify(data, null, 2));
+        setSavedJSON(JSON.stringify(prepareServerData(data), null, 2));
         onLoadFlow(data);
       }
     });
@@ -1109,6 +1126,8 @@ export default function PipelineEditor(props) {
                     <button id="clear" disabled={nodes.length === 0} onClick={() => setModal('clear')}>Clear</button>
                     <button id="saveBtn" onClick={() => { if (currentFileName) onSave(currentFileName); else setModal('saveAs') }}>Save</button>
                     <button id="saveAsBtn" onClick={() => setModal('saveAs')}>Save As...</button>
+                    <button id="1" onClick={() => console.log(savedJSON)}>savedJSON</button>
+                    <button id="2" onClick={() => console.log(generateSaveJSON())}>generateSaveJSON</button>
                   </>
                 }
               </div>

--- a/ui/src/components/PipelineEditor/PipelineEditor.js
+++ b/ui/src/components/PipelineEditor/PipelineEditor.js
@@ -70,10 +70,6 @@ document.addEventListener('keydown', e => {
   }
 });
 
-document.addEventListener("beforeunload", function(event) {
-  event.preventDefault();
-});
-
 export default function PipelineEditor(props) {
   const reactFlowWrapper = useRef(null);
   const [nodes, setNodes, onNodesChange] = useNodesState([]);
@@ -887,6 +883,12 @@ export default function PipelineEditor(props) {
     setEdges([]);
     hideModal('clear');
   }, [setEditSession, setCurrentFileName, setNodes, setEdges, hideModal])
+
+  const handleBeforeUnload = function(event) {
+    event.preventDefault();
+  }
+  
+  document.addEventListener("beforeunload", handleBeforeUnload);
 
   return (
     <div id="editorLayout">

--- a/ui/src/components/PipelineEditor/PipelineEditor.js
+++ b/ui/src/components/PipelineEditor/PipelineEditor.js
@@ -960,6 +960,7 @@ export default function PipelineEditor(props) {
     }
   }, [nodes, edges, savedJSON]);
 
+  //removes event listener when PipelineEditor component unmounts
   useEffect(() => {
     return () => {
       window.removeEventListener('beforeunload', handleBeforeUnload); //so that this event listener doesn't persist when the component unmounts (e.g. React Router change)

--- a/ui/src/components/PipelineEditor/PipelineEditor.js
+++ b/ui/src/components/PipelineEditor/PipelineEditor.js
@@ -782,6 +782,12 @@ export default function PipelineEditor(props) {
     }
   }, [reactFlowInstance]);
 
+  /**
+    * saveJSON instead of currentFileName in dependencies: after a pipeline is loaded from a file, when it is saved, 
+    * savedJSON changes but currentFileName doesn't and localStorage should be updated in this specific case.
+    * currentFileName should be added to these dependencies for a case where two different server files are identical 
+    * except for their file names, but this seems redundant and inefficient for most cases.
+    */
   useEffect(()=> {
     if (reactFlowInstance != null) {
       if (savedJSON !== null) { //when pipeline is loaded from file, it's not automatically saved to the server, but currentFileName is still set
@@ -790,7 +796,7 @@ export default function PipelineEditor(props) {
         localStorage.setItem("currentFileName", '');
       }
     }
-  }, [currentFileName]); 
+  }, [savedJSON]); 
 
   const onLoadFlow = useCallback(async (flow) => {
     if (flow) {

--- a/ui/src/components/PipelineEditor/PipelineEditor.js
+++ b/ui/src/components/PipelineEditor/PipelineEditor.js
@@ -645,7 +645,7 @@ export default function PipelineEditor(props) {
     }
 
     return JSON.stringify(flow, null, 2);
-  }, [reactFlowInstance]);
+  }, [inputList, outputList, metadata, reactFlowInstance]);
 
   const onSave = useCallback((fileName) => {
     let saveJSON = generateSaveJSON();
@@ -685,7 +685,7 @@ export default function PipelineEditor(props) {
           });
       }
     }
-  }, [inputList, outputList, metadata, showAlert, generateSaveJSON]);
+  }, [showAlert, generateSaveJSON]);
 
   const onLoadFromFileBtnClick = () => inputFile.current.click(); // will call onLoad
 

--- a/ui/src/components/PipelineEditor/PipelineEditor.js
+++ b/ui/src/components/PipelineEditor/PipelineEditor.js
@@ -790,7 +790,7 @@ export default function PipelineEditor(props) {
         localStorage.setItem("currentFileName", '');
       }
     }
-  }, [savedJSON]); 
+  }, [currentFileName]); 
 
   const onLoadFlow = useCallback(async (flow) => {
     if (flow) {

--- a/ui/src/components/PipelineEditor/PipelineEditor.js
+++ b/ui/src/components/PipelineEditor/PipelineEditor.js
@@ -80,7 +80,7 @@ export default function PipelineEditor(props) {
   const [outputList, setOutputList] = useState([]);
   const [metadata, setMetadata] = useState("");
   const [currentFileName, setCurrentFileName] = useState("");
-  const [beforeUnloadEventListener, setBeforeUnloadEventListener] = useState(false);
+  const [hasChanged, setHasChanged] = useState(false);
   const [savedJSON, setSavedJSON] = useState(null);
 
   const [editSession, setEditSession] = useState(Math.random());
@@ -935,26 +935,26 @@ export default function PipelineEditor(props) {
   useEffect(() => {
     if (savedJSON === null) {
       if (nodes.length === 0) {
-        if (beforeUnloadEventListener) {
+        if (hasChanged) {
           window.removeEventListener('beforeunload', handleBeforeUnload);
-          setBeforeUnloadEventListener(false);
+          setHasChanged(false);
         }
       } else {
-        if (!beforeUnloadEventListener) {
+        if (!hasChanged) {
           window.addEventListener('beforeunload', handleBeforeUnload);
-          setBeforeUnloadEventListener(true);
+          setHasChanged(true);
         }
       }
     } else {
       if (savedJSON === generateSaveJSON()) {
-        if (beforeUnloadEventListener) {
+        if (hasChanged) {
           window.removeEventListener('beforeunload', handleBeforeUnload);
-          setBeforeUnloadEventListener(false);
+          setHasChanged(false);
         }
       } else {
-        if (!beforeUnloadEventListener) {
+        if (!hasChanged) {
           window.addEventListener('beforeunload', handleBeforeUnload);
-          setBeforeUnloadEventListener(true);
+          setHasChanged(true);
         }
       }
     }

--- a/ui/src/components/PipelineEditor/PipelineEditor.js
+++ b/ui/src/components/PipelineEditor/PipelineEditor.js
@@ -1126,8 +1126,6 @@ export default function PipelineEditor(props) {
                     <button id="clear" disabled={nodes.length === 0} onClick={() => setModal('clear')}>Clear</button>
                     <button id="saveBtn" onClick={() => { if (currentFileName) onSave(currentFileName); else setModal('saveAs') }}>Save</button>
                     <button id="saveAsBtn" onClick={() => setModal('saveAs')}>Save As...</button>
-                    <button id="1" onClick={() => console.log(savedJSON)}>savedJSON</button>
-                    <button id="2" onClick={() => console.log(generateSaveJSON())}>generateSaveJSON</button>
                   </>
                 }
               </div>

--- a/ui/src/components/PipelineEditor/PipelineEditor.js
+++ b/ui/src/components/PipelineEditor/PipelineEditor.js
@@ -781,12 +781,11 @@ export default function PipelineEditor(props) {
     });
   };
 
-  //restores the last pipeline the user was editing from the localStorage
+  // Restores the last pipeline the user was editing from the localStorage.
+  // Executed once when opening the editor.
   useEffect(()=> {
-    if(localStorage.getItem("currentFileName")){
-      if (reactFlowInstance != null) {
+    if(localStorage.getItem("currentFileName") && reactFlowInstance){
         onLoadFromLocalStorage(localStorage.getItem("currentFileName"));
-      }
     }
   }, [reactFlowInstance]);
 
@@ -976,14 +975,14 @@ export default function PipelineEditor(props) {
       window.addEventListener('beforeunload', handleBeforeUnload);
       setUnsavedChanges(true);
     }
-  }, [nodes, edges, savedJSON]);
+  }, [nodes, edges, savedJSON, handleBeforeUnload]);
 
   //removes event listener when PipelineEditor component unmounts
   useEffect(() => {
     return () => {
       window.removeEventListener('beforeunload', handleBeforeUnload); //so that this event listener doesn't persist when the component unmounts (e.g. React Router change)
     };
-  }, [])
+  }, [handleBeforeUnload])
 
   return (
     <div id="editorLayout">

--- a/ui/src/components/PipelineEditor/PipelineEditor.js
+++ b/ui/src/components/PipelineEditor/PipelineEditor.js
@@ -932,7 +932,7 @@ export default function PipelineEditor(props) {
     event.returnValue = '';
   }, []);
 
-  useEffect(()=> {
+  useEffect(() => {
     if (savedJSON === null) {
       if (nodes.length === 0) {
         if (beforeUnloadEventListener) {
@@ -945,14 +945,7 @@ export default function PipelineEditor(props) {
           setBeforeUnloadEventListener(true);
         }
       }
-    }
-    return () => {
-      window.removeEventListener('beforeunload', handleBeforeUnload); //so that this event listener doesn't persist when the component unmounts (e.g. React Router change)
-    };
-  }, [nodes.length, edges.length]);
-
-  useEffect(()=> {
-    if (savedJSON !== null) {
+    } else {
       if (savedJSON === generateSaveJSON()) {
         if (beforeUnloadEventListener) {
           window.removeEventListener('beforeunload', handleBeforeUnload);
@@ -965,10 +958,13 @@ export default function PipelineEditor(props) {
         }
       }
     }
+  }, [nodes.length, edges.length, savedJSON]);
+
+  useEffect(() => {
     return () => {
       window.removeEventListener('beforeunload', handleBeforeUnload); //so that this event listener doesn't persist when the component unmounts (e.g. React Router change)
     };
-  }, [savedJSON, nodes.length, edges.length]);
+  }, [])
 
   return (
     <div id="editorLayout">

--- a/ui/src/components/PipelineEditor/PipelineEditor.js
+++ b/ui/src/components/PipelineEditor/PipelineEditor.js
@@ -937,19 +937,13 @@ export default function PipelineEditor(props) {
     event.preventDefault();
     event.returnValue = '';
   }, []);
-  const handlePopstate = useCallback((event) => {
-    event.preventDefault();
-    event.returnValue = '';
-  }, []);
 
   useEffect(() => {
     if (hasUnsavedChanges && ((savedJSON === null && nodes.length === 0) || (savedJSON !== null && savedJSON === generateSaveJSON()))) {
       window.removeEventListener('beforeunload', handleBeforeUnload);
-      window.removeEventListener('popstate', handlePopstate);
       setUnsavedChanges(false);
     } else if (!hasUnsavedChanges && ((savedJSON === null && nodes.length !== 0) || (savedJSON !== null && savedJSON !== generateSaveJSON()))) {
       window.addEventListener('beforeunload', handleBeforeUnload);
-      window.addEventListener('popstate', handlePopstate);
       setUnsavedChanges(true);
     }
   }, [nodes, edges, savedJSON, handleBeforeUnload]);
@@ -960,13 +954,6 @@ export default function PipelineEditor(props) {
       window.removeEventListener('beforeunload', handleBeforeUnload); //so that this event listener doesn't persist when the component unmounts (e.g. React Router change)
     };
   }, [handleBeforeUnload])
-
-  //removes event listener when PipelineEditor component unmounts
-  useEffect(() => {
-    return () => {
-      window.removeEventListener('popstate', handlePopstate);
-    };
-  }, [handlePopstate])
 
   return (
     <div id="editorLayout">

--- a/ui/src/components/PipelineEditor/PipelineEditor.js
+++ b/ui/src/components/PipelineEditor/PipelineEditor.js
@@ -3,7 +3,7 @@ import "react-flow-renderer/dist/theme-default.css";
 import "./Editor.css";
 import { TextField, Button, Dialog, DialogTitle, DialogContent, DialogActions, Alert, AlertTitle, Snackbar, DialogContentText } from '@mui/material';
 
-import React, { useState, useRef, useCallback, useEffect } from "react";
+import React, { useState, useRef, useCallback, useEffect, useContext } from "react";
 import ReactFlow, {
   ReactFlowProvider,
   addEdge,
@@ -37,6 +37,7 @@ import {
 import sleep from "../../utils/Sleep";
 import { IOListPane } from "./IOListPane";
 import { MetadataPane } from "./MetadataPane";
+import NavigationContext from "../../NavigationContext";
 
 const yaml = require('js-yaml');
 const _lang = require('lodash/lang');
@@ -80,8 +81,8 @@ export default function PipelineEditor(props) {
   const [outputList, setOutputList] = useState([]);
   const [metadata, setMetadata] = useState("");
   const [currentFileName, setCurrentFileName] = useState("");
-  const [hasChanged, setHasChanged] = useState(false);
   const [savedJSON, setSavedJSON] = useState(null);
+  const { hasChanged, setHasChanged } = useContext(NavigationContext);
 
   const [editSession, setEditSession] = useState(Math.random());
 

--- a/ui/src/components/PipelineEditor/PipelineEditor.js
+++ b/ui/src/components/PipelineEditor/PipelineEditor.js
@@ -710,23 +710,6 @@ export default function PipelineEditor(props) {
     }
   };
 
-  //when loading pipeline from the server, the data has no weights or different weights compared to the output of generateSaveJSON()
-  //this function does exactly what generateSaveJSON does to add weights, so that savedJSON and generateSaveJSON() can be compared to detect changes
-  const prepareServerData = (data) => {
-    let dataCopy = _lang.cloneDeep(data);
-    let i = 0;
-    for (let key in dataCopy.inputs){
-      dataCopy.inputs[key].weight = i;
-      i++;
-    }
-    let j = 0;
-    for (let key in dataCopy.outputs){
-      dataCopy.outputs[key].weight = j;
-      j++
-    }
-    return dataCopy;
-  };
-
   const onLoadFromServerBtnClick = (event) => {
     event.stopPropagation();
     event.preventDefault();
@@ -753,7 +736,7 @@ export default function PipelineEditor(props) {
                 )
               } else {
                 setCurrentFileName(descriptionFile);
-                setSavedJSON(JSON.stringify(prepareServerData(data), null, 2));
+                setSavedJSON(JSON.stringify(data, null, 2));
                 onLoadFlow(data);
               }
             });
@@ -775,7 +758,7 @@ export default function PipelineEditor(props) {
         )
       } else {
         setCurrentFileName(descriptionFile);
-        setSavedJSON(JSON.stringify(prepareServerData(data), null, 2));
+        setSavedJSON(JSON.stringify(data, null, 2));
         onLoadFlow(data);
       }
     });

--- a/ui/src/index.js
+++ b/ui/src/index.js
@@ -28,8 +28,7 @@ function NotFound() {
 
 function App() {
   const [popupContent, setPopupContent] = useState();
-
-  const [hasChanged, setHasChanged] = useState(false);
+  const [hasUnsavedChanges, setUnsavedChanges] = useState(false);
 
   return <BrowserRouter>
     <Routes>
@@ -38,21 +37,21 @@ function App() {
       <Route path="script-form/:pipeline?/:runHash?" element={
         <Layout right={<PipelinePage runType="script" />} />
       } />
-      
+
       <Route path="pipeline-form/:pipeline?/:runHash?" element={
         <Layout right={<PipelinePage runType="pipeline" />} />
       } />
 
       <Route path="pipeline-editor" element={
-        <Layout left={<StepChooser popupContent={popupContent} setPopupContent={setPopupContent}/>}
+        <Layout left={<StepChooser popupContent={popupContent} setPopupContent={setPopupContent} />}
           right={
             <Suspense fallback={<Spinner />}>
-              <PipelineEditor hasChanged={hasChanged} setHasChanged={setHasChanged}/>
+              <PipelineEditor hasUnsavedChanges={hasUnsavedChanges} setUnsavedChanges={setUnsavedChanges}/>
             </Suspense>
           }
           popupContent={popupContent}
-          setPopupContent={setPopupContent} 
-          hasChanged={hasChanged} />
+          setPopupContent={setPopupContent}
+          hasUnsavedChanges={hasUnsavedChanges} />
       } />
 
       <Route path="versions" element={

--- a/ui/src/index.js
+++ b/ui/src/index.js
@@ -15,7 +15,6 @@ import StepChooser from "./components/PipelineEditor/StepChooser";
 import { Layout } from './Layout.js';
 import Versions from './components/Versions';
 import { Spinner } from './components/Spinner';
-import NavigationContext from './NavigationContext';
 const PipelineEditor = lazy(() => import("./components/PipelineEditor/PipelineEditor"));
 
 function NotFound() {

--- a/ui/src/index.js
+++ b/ui/src/index.js
@@ -15,6 +15,7 @@ import StepChooser from "./components/PipelineEditor/StepChooser";
 import { Layout } from './Layout.js';
 import Versions from './components/Versions';
 import { Spinner } from './components/Spinner';
+import NavigationContext from './NavigationContext';
 const PipelineEditor = lazy(() => import("./components/PipelineEditor/PipelineEditor"));
 
 function NotFound() {
@@ -29,7 +30,11 @@ function NotFound() {
 function App() {
   const [popupContent, setPopupContent] = useState();
 
-  return <BrowserRouter>
+  const [hasChanged, setHasChanged] = useState(false);
+
+  return (
+  <NavigationContext.Provider value={{ hasChanged, setHasChanged }}> 
+  <BrowserRouter>
     <Routes>
       <Route path="/" element={<Layout />} />
 
@@ -62,7 +67,8 @@ function App() {
 
     </Routes>
   </BrowserRouter>
-}
+  </NavigationContext.Provider>
+)};
 
 const root = createRoot(document.getElementById('root'));
 root.render(<App />);

--- a/ui/src/index.js
+++ b/ui/src/index.js
@@ -3,12 +3,10 @@ import { createRoot } from 'react-dom/client';
 import './index.css';
 import reportWebVitals from './reportWebVitals';
 import {
-  BrowserRouter,
-  Routes,
-  Route,
+  createBrowserRouter, 
+  RouterProvider,
   useLocation,
-} from "react-router-dom";
-
+} from 'react-router-dom';
 
 import { PipelinePage } from "./components/PipelinePage";
 import StepChooser from "./components/PipelineEditor/StepChooser";
@@ -28,42 +26,42 @@ function NotFound() {
 
 function App() {
   const [popupContent, setPopupContent] = useState();
-  const [hasUnsavedChanges, setUnsavedChanges] = useState(false);
 
-  return <BrowserRouter>
-    <Routes>
-      <Route path="/" element={<Layout />} />
+  const router = createBrowserRouter([
+    {
+      path: "/",
+      element: <Layout />,
+    },
+    {
+      path: "script-form/:pipeline?/:runHash?",
+      element: <Layout right={<PipelinePage runType="script" />} />,
+    },
+    {
+      path: "pipeline-form/:pipeline?/:runHash?",
+      element: <Layout right={<PipelinePage runType="pipeline" />} />,
+    }, 
+    {
+      path: "pipeline-editor",
+      element: <Layout left={<StepChooser popupContent={popupContent} setPopupContent={setPopupContent} />}
+      right={
+        <Suspense fallback={<Spinner />}>
+          <PipelineEditor />
+        </Suspense>
+      }
+      popupContent={popupContent}
+      setPopupContent={setPopupContent} />,
+    },
+    {
+      path: "versions",
+      element: <Layout right={<Versions />} />,
+    },
+    {
+      path: "*",
+      element: <Layout right={<NotFound />} />,
+    }
+  ]);
 
-      <Route path="script-form/:pipeline?/:runHash?" element={
-        <Layout right={<PipelinePage runType="script" />} />
-      } />
-
-      <Route path="pipeline-form/:pipeline?/:runHash?" element={
-        <Layout right={<PipelinePage runType="pipeline" />} />
-      } />
-
-      <Route path="pipeline-editor" element={
-        <Layout left={<StepChooser popupContent={popupContent} setPopupContent={setPopupContent} />}
-          right={
-            <Suspense fallback={<Spinner />}>
-              <PipelineEditor hasUnsavedChanges={hasUnsavedChanges} setUnsavedChanges={setUnsavedChanges}/>
-            </Suspense>
-          }
-          popupContent={popupContent}
-          setPopupContent={setPopupContent}
-          hasUnsavedChanges={hasUnsavedChanges} />
-      } />
-
-      <Route path="versions" element={
-        <Layout right={<Versions />} />
-      } />
-
-      <Route path="*" element={
-        <Layout right={<NotFound />} />
-      } />
-
-    </Routes>
-  </BrowserRouter>
+  return <RouterProvider router={router} />;
 };
 
 const root = createRoot(document.getElementById('root'));

--- a/ui/src/index.js
+++ b/ui/src/index.js
@@ -32,9 +32,7 @@ function App() {
 
   const [hasChanged, setHasChanged] = useState(false);
 
-  return (
-  <NavigationContext.Provider value={{ hasChanged, setHasChanged }}> 
-  <BrowserRouter>
+  return <BrowserRouter>
     <Routes>
       <Route path="/" element={<Layout />} />
 
@@ -47,14 +45,15 @@ function App() {
       } />
 
       <Route path="pipeline-editor" element={
-        <Layout left={<StepChooser popupContent={popupContent} setPopupContent={setPopupContent} />}
+        <Layout left={<StepChooser popupContent={popupContent} setPopupContent={setPopupContent}/>}
           right={
             <Suspense fallback={<Spinner />}>
-              <PipelineEditor />
+              <PipelineEditor hasChanged={hasChanged} setHasChanged={setHasChanged}/>
             </Suspense>
           }
           popupContent={popupContent}
-          setPopupContent={setPopupContent} />
+          setPopupContent={setPopupContent} 
+          hasChanged={hasChanged} />
       } />
 
       <Route path="versions" element={
@@ -67,8 +66,7 @@ function App() {
 
     </Routes>
   </BrowserRouter>
-  </NavigationContext.Provider>
-)};
+};
 
 const root = createRoot(document.getElementById('root'));
 root.render(<App />);


### PR DESCRIPTION
### Content Overview
- Use of localStorage to restore user's previous pipeline they were editing before leaving the page.
- **beforeunload**: When there are unsaved changes and user tries to close the window, close the tab or reload the tab, there is a warning message.
- **unstable_useBlocker**: Inside the react app, when there are unsaved changes and the user tries to leave the *pipeline-editor* page, there is a custom warning message.
- Transition from BrowserRouter to createBrowserRouter router, so that unstable_useBlocker works. Prompt doesn't work in newer versions of react router. In newer versions of react router, you can only use unstable_useBlocker or unstable_usePrompt, but those only work on routers that support the new data APIs: *createBrowserRouter*, createMemoryRouter, createHashRouter or createStaticRouter, not in: *BrowserRouter*, MemoryRouter, HashRouter, NativeRouter or StaticRouter.

closes #37