### PR TITLE
Docker hub staging

### DIFF
--- a/README-dev.md
+++ b/README-dev.md
@@ -44,7 +44,30 @@ This command enables:
 
 Once in a while you should use `docker compose -f compose.yml -f compose.dev.yml pull` to have the latest base images.
 
-## Debugging prod servers
+## Releasing a server version
+
+The servers are versionned by date of build of the docker image. One can check the version in the version tab of the UI.
+
+### Creating a staging build
+1. Create a branch that ends with "staging" from the head of the main branch.
+2. Merge your changes to that branch. The docker hub GH action will trigger for branch main and any branch with name ending by "staging". The branch name is appended to the tag of the docker image. See
+    - [.github/workflows/docker_script-server.yml](.github/workflows/docker_ui.yml)
+    - [.github/workflows/docker_ui.yml](.github/workflows/docker_ui.yml)
+3. **Caveat:** this only compiles the image where the paths were modified. For example, if `viewer` folder is modified, only the gateway will be rebuilt. However, the server will look for both images with the same prefix. In this case `script-server-staging` might not exist, or might be outdated. It is possible to launch the build of the script-server manually to make sure it exists and is up to date.
+    1. On github website, navigate to the Actions tab
+    2. open the desired action
+    3. Click on the arrow next to "run workflow"
+    4. Select the desired staging branch
+    5. Run workflow
+    6. Wait for completion
+4. It is now possible to test the staging prod servers by running `./server-up.sh <branchname>`. The launch script will look for this special tag in the docker hub.For example, `./server-up.sh staging` will download and use both "gateway-staging" and "script-server-staging" images.
+5. Send the above command to a few beta users.
+
+### Public release
+The changes are live as soon as they are merged to main branch: the dockers are built, pushed to [geobon's docker hub](https://hub.docker.com/r/geobon/bon-in-a-box), and next time someone starts the server, the new dockers will be pulled.
+
+
+### Debugging prod servers
 
 Yes, we all know problems occur in production that do not happen in dev mode. So in order to build and test production dockers locally, do the following:
 

--- a/prod-server.sh
+++ b/prod-server.sh
@@ -57,7 +57,8 @@ function command { # args appended to the docker compose command
     export DOCKER_GID="$(getent group docker | cut -d: -f3)"
 
     # Set the branch suffix. This allows to use a staging build.
-    branch=$(git branch --show-current)
+    # We use remote.origin.fetch because of the partial checkout, see server-up.sh.
+    branch=$(git -C .server config remote.origin.fetch | sed 's/.*remotes\/origin\///')
     if [[ $branch == *"staging" ]]; then
         export DOCKER_SUFFIX="-$(git branch --show-current)"
     else

--- a/prod-server.sh
+++ b/prod-server.sh
@@ -60,7 +60,7 @@ function command { # args appended to the docker compose command
     # We use remote.origin.fetch because of the partial checkout, see server-up.sh.
     branch=$(git -C .server config remote.origin.fetch | sed 's/.*remotes\/origin\///')
     if [[ $branch == *"staging" ]]; then
-        export DOCKER_SUFFIX="-$(git branch --show-current)"
+        export DOCKER_SUFFIX="-$branch"
     else
         export DOCKER_SUFFIX=""
     fi

--- a/prod-server.sh
+++ b/prod-server.sh
@@ -59,9 +59,9 @@ function command { # args appended to the docker compose command
     # Set the branch suffix. This allows to use a staging build.
     branch=$(git branch --show-current)
     if [[ $branch == *"staging" ]]; then
-        DOCKER_SUFFIX="-$(git branch --show-current)"
+        export DOCKER_SUFFIX="-$(git branch --show-current)"
     else
-        DOCKER_SUFFIX=""
+        export DOCKER_SUFFIX=""
     fi
 
     # On Windows, getent will not work. We leave the default users (anyways permissions don't matter).


### PR DESCRIPTION
Also includes changes from https://github.com/GEO-BON/bon-in-a-box-pipeline-engine/commit/07cd56b5d9ec3ac2dd86c0664e9d654be37c36e6 and https://github.com/GEO-BON/bon-in-a-box-pipeline-engine/commit/07cd56b5d9ec3ac2dd86c0664e9d654be37c36e6, that were already merged to main.

With this PR, the docker hub GH action will trigger for branch main and any branch with name ending by "staging".
The branch name is appended to the tag of the docker image. 
The launch script will look for this special tag in the docker hub.

For example, for branch "staging", the docker hub image will be named "gateway-staging" and "script-server-staging". Launching with command `server-up.sh staging` will download and use both images.

**Caveat:** this only compiles the image where the paths were modified. For example, if `ui` folder is modified, only the gateway will be rebuilt. However, the server will look for both images with the same prefix. In this case `script-server-staging` might not exist, or might be outdated. It is possible to launch the build of the script-server manually to make sure it exists and is up to date.

closes #119 