### PR TITLE
Conda locking mechanism.

### DIFF
--- a/script-server/src/main/kotlin/org/geobon/script/ScriptRun.kt
+++ b/script-server/src/main/kotlin/org/geobon/script/ScriptRun.kt
@@ -361,7 +361,7 @@ class ScriptRun( // Constructor used in single script run
                                             process.destroy()
                                         }
 
-                                        if (!process.waitFor(10, TimeUnit.SECONDS)) {
+                                        if (!process.waitFor(30, TimeUnit.SECONDS)) {
                                             log(logger::info, "$event: cancellation timeout elapsed.")
                                             process.destroyForcibly()
                                         }

--- a/script-server/src/main/kotlin/org/geobon/script/ScriptRun.kt
+++ b/script-server/src/main/kotlin/org/geobon/script/ScriptRun.kt
@@ -236,6 +236,9 @@ class ScriptRun( // Constructor used in single script run
                                     set -o pipefail
                                     echo "$condaEnvYml" > $condaEnvFile.2.yml ; assertSuccess
 
+                                    trap "rm -rf $condaEnvFile.lock 2>/dev/null" SIGINT SIGTERM EXIT
+                                    while ! mkdir $condaEnvFile.lock 2>/dev/null; do echo "waiting for conda lockfile..."; sleep 2s; done;
+
                                     if [ ! -f "$condaEnvFile.yml" ]; then
                                         echo "Creating new conda environment $condaEnvName..."
                                         createLogs=$(mamba env create -f $condaEnvFile.2.yml 2>&1 | tee -a ${logFile.absolutePath})
@@ -271,6 +274,8 @@ class ScriptRun( // Constructor used in single script run
                                         mamba env create -f $condaEnvFile.yml
                                         mamba activate $condaEnvName
                                     fi
+
+                                    rm -rf $condaEnvFile.lock 2>/dev/null
                                 """.trimIndent()
                             } else {
                                 """

--- a/script-server/src/main/kotlin/org/geobon/script/ScriptRun.kt
+++ b/script-server/src/main/kotlin/org/geobon/script/ScriptRun.kt
@@ -236,8 +236,9 @@ class ScriptRun( // Constructor used in single script run
                                     set -o pipefail
                                     echo "$condaEnvYml" > $condaEnvFile.2.yml ; assertSuccess
 
-                                    trap "rm -rf $condaEnvFile.lock 2>/dev/null" SIGINT SIGTERM EXIT
                                     while ! mkdir $condaEnvFile.lock 2>/dev/null; do echo "waiting for conda lockfile..."; sleep 2s; done;
+                                    trap "echo 'Removing conda lock file for interrupted process'; rm -rf $condaEnvFile.lock 2>/dev/null; exit 1" SIGINT SIGTERM
+                                    echo "Conda lock file acquired"
 
                                     if [ ! -f "$condaEnvFile.yml" ]; then
                                         echo "Creating new conda environment $condaEnvName..."
@@ -275,7 +276,9 @@ class ScriptRun( // Constructor used in single script run
                                         mamba activate $condaEnvName
                                     fi
 
+                                    echo "Removing conda lock file"
                                     rm -rf $condaEnvFile.lock 2>/dev/null
+                                    trap - SIGINT SIGTERM
                                 """.trimIndent()
                             } else {
                                 """

--- a/script-server/src/main/kotlin/org/geobon/script/ScriptRun.kt
+++ b/script-server/src/main/kotlin/org/geobon/script/ScriptRun.kt
@@ -340,13 +340,14 @@ class ScriptRun( // Constructor used in single script run
 
                                         if (pidFile.exists() && container.isExternal()) {
                                             val pid = pidFile.readText().trim()
-                                            log(logger::debug, "$event: killing runner process '$pid'")
+                                            log(logger::debug, "$event: gracefully stopping runner process '$pid'")
 
                                             ProcessBuilder(container.dockerCommandList + listOf(
                                                     "kill", "-s", "TERM", pid
                                             )).start()
 
-                                            if (!process.waitFor(10, TimeUnit.SECONDS)) {
+                                            if (!process.waitFor(30, TimeUnit.SECONDS)) {
+                                                log(logger::debug, "$event: forcefully stopping runner process '$pid' after 30 seconds")
                                                 ProcessBuilder(container.dockerCommandList + listOf(
                                                         "kill", "-s", "KILL", pid
                                                 )).start()

--- a/script-server/src/main/kotlin/org/geobon/script/ScriptRun.kt
+++ b/script-server/src/main/kotlin/org/geobon/script/ScriptRun.kt
@@ -288,6 +288,7 @@ class ScriptRun( // Constructor used in single script run
                             // eval and source commands to initialize mamba, see https://stackoverflow.com/a/75246428/3519951
                             "bash", "-c",
                             """
+                                echo $$ > ${pidFile.absolutePath}
                                 source /.bashrc
                                 $activateEnvironment
                                 Rscript -e '


### PR DESCRIPTION
Will allow us to re-run the pipeline for [#201](https://github.com/GEO-BON/bon-in-a-box-pipelines/issues/201)

**Known caveat:** the conda lock file will remain in the case that during conda installation, the process doesn't respond to SIGTERM, and after 30 seconds, a SIGKILL is issued. SIGKILL does not allow for traps to execute cleanup code. In practice, I was not able to reproduce this as the installation always swiftly responded to the SIGTERM signal.