### PR TITLE
Remove resizing of left pane

### DIFF
--- a/ui/src/components/PipelineEditor/StepChooser.css
+++ b/ui/src/components/PipelineEditor/StepChooser.css
@@ -1,5 +1,4 @@
 .left-pane {
-    resize: horizontal;
     overflow-y: scroll;
     overflow-x: hidden;
 }


### PR DESCRIPTION
Removes the resizing of the left-pane of the pipeline editor
closes #71 