### PR TITLE
All python log output will be flushed automatically

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -43,6 +43,7 @@ services:
     env_file:
       - ${PIPELINE_REPO_PATH}/runner.env
     environment:
+      PYTHONUNBUFFERED: 1 
       SCRIPT_LOCATION: /scripts
       USERDATA_LOCATION: /userdata
       OUTPUT_LOCATION: /output


### PR DESCRIPTION
Python PYTHONUNBUFFERED=1 environment variable is set so that output buffer is flushed automatically, no other parameter need to be set.
closes #183 