### PR TITLE
Add credit roles to pipeline metadata file

### DIFF
--- a/.github/pipelineValidationSchema.yml
+++ b/.github/pipelineValidationSchema.yml
@@ -45,6 +45,12 @@ metadata:
           identifier:
             type: string
             required: false
+          role:
+            type: list
+            required: false
+            schema:
+              type: string
+
 
     reviewer:
       type: list

--- a/.github/scriptValidationSchema.yml
+++ b/.github/scriptValidationSchema.yml
@@ -47,6 +47,11 @@ author:
       identifier:
         type: string
         required: false
+      role:
+        type: list
+        required: false
+        schema:
+          type: string
 
 reviewer:
   type: list

--- a/how_to_contribute.qmd
+++ b/how_to_contribute.qmd
@@ -284,6 +284,7 @@ author:
   - name: Jane Doe
     email: jane.doe@example.com
     identifier: https://orcid.org/0000-0000-0000-0000
+    role: [Software, Visualization, Conceptualization]
 reviewer:
   - name: John Smith
     email: john.smith@example.com
@@ -342,6 +343,7 @@ author: # 1 to many
   - name: # Full name
     email: # Optional, email address of the author. This will be publicly available
     identifier: # Optional, full URL of a unique digital identifier, such as an ORCID.
+    role: # Optional, array of roles undertaken by the author in their contribution. Suggested to use CRediT roles (https://credit.niso.org/).
 license: # Optional. If unspecified, the project's MIT license will apply.
 external_link: # Optional, link to a separate project, GitHub repo, etc.
 timeout: # Optional, in minutes. By defaults scripts time out after 24h to avoid hung process to consume resources. It can be made longer for heavy processes.

--- a/script-server/api/openapi.yaml
+++ b/script-server/api/openapi.yaml
@@ -451,11 +451,18 @@ components:
               identifier:
                 type: string
                 description: Full URL of a unique digital identifier such as an ORCID
+              role:
+                type: array
+                description: Role of the author in the contribution. Suggested to use CRediT roles (https://credit.niso.org/)
+                items:
+                  type: string
+
           example:
             - name: Jane Doe
             - name: John Doe
               email: john.doe@example.org
               identifier: https://orcid.org/0000-0000-0000-0000
+              role: Software
         reviewer:
           type: array
           items:

--- a/script-server/src/test/resources/pipelines/assertNull_fromConstant.json
+++ b/script-server/src/test/resources/pipelines/assertNull_fromConstant.json
@@ -69,7 +69,8 @@
     "author": [
       {
         "name": "Jean-Michel Lord",
-        "identifier": "https://orcid.org/0009-0007-3826-1125"
+        "identifier": "https://orcid.org/0009-0007-3826-1125",
+        "role": ["Conceptualization", "Data Curation", "Investigation"]
       }
     ]
   }

--- a/script-server/src/test/resources/scripts/assertNull.yml
+++ b/script-server/src/test/resources/scripts/assertNull.yml
@@ -6,6 +6,9 @@ lifecycle:
   message: bla bla
 author:
   - name: Jean-Michel Lord
+    role:
+      - Software
+      - Visualization
 reviewer:
   - name: No One
 inputs:

--- a/ui/BonInABoxScriptService/docs/InfoAuthorInner.md
+++ b/ui/BonInABoxScriptService/docs/InfoAuthorInner.md
@@ -7,5 +7,6 @@ Name | Type | Description | Notes
 **name** | **String** | Full name of the author | [optional] 
 **email** | **String** | Email of the author | [optional] 
 **identifier** | **String** | Full URL of a unique digital identifier such as an ORCID | [optional] 
+**role** | **[String]** | Role of the author in the contribution. Suggested to use CRediT roles (https://credit.niso.org/) | [optional] 
 
 

--- a/ui/BonInABoxScriptService/src/model/InfoAuthorInner.js
+++ b/ui/BonInABoxScriptService/src/model/InfoAuthorInner.js
@@ -56,6 +56,9 @@ class InfoAuthorInner {
             if (data.hasOwnProperty('identifier')) {
                 obj['identifier'] = ApiClient.convertToType(data['identifier'], 'String');
             }
+            if (data.hasOwnProperty('role')) {
+                obj['role'] = ApiClient.convertToType(data['role'], ['String']);
+            }
         }
         return obj;
     }
@@ -77,6 +80,10 @@ class InfoAuthorInner {
         // ensure the json data is a string
         if (data['identifier'] && !(typeof data['identifier'] === 'string' || data['identifier'] instanceof String)) {
             throw new Error("Expected the field `identifier` to be a primitive type in the JSON string but got " + data['identifier']);
+        }
+        // ensure the json data is an array
+        if (!Array.isArray(data['role'])) {
+            throw new Error("Expected the field `role` to be an array in the JSON data but got " + data['role']);
         }
 
         return true;
@@ -104,6 +111,12 @@ InfoAuthorInner.prototype['email'] = undefined;
  * @member {String} identifier
  */
 InfoAuthorInner.prototype['identifier'] = undefined;
+
+/**
+ * Role of the author in the contribution. Suggested to use CRediT roles (https://credit.niso.org/)
+ * @member {Array.<String>} role
+ */
+InfoAuthorInner.prototype['role'] = undefined;
 
 
 

--- a/ui/src/components/StepDescription.jsx
+++ b/ui/src/components/StepDescription.jsx
@@ -27,17 +27,19 @@ function generatePersonList(list) {
     return list.map((person, i, array) => {
         let email = person.email && <a href={'mailto:' + person.email} style={{textDecoration:'none'}}> &#9993;</a>
         let comma = (i !== array.length - 1) && ',' // Comma will be inside link but the space outside the link.
+        let role = person.role && <span> ({person.role.reduce((r1, r2) => r1 + ", " + r2)})</span>
         if (person.identifier)
             return <span key={i}>
                 <a href={person.identifier} target="_blank">
                     {person.name}{!email && comma}
                 </a>
+                {role}
                 {email && <>{email}{comma}</>}
                 &nbsp;
             </span>
 
         else
-            return <span key={i}>{person.name}{email}{comma} </span>
+            return <span key={i}>{person.name}{role}{email}{comma} </span>
     })
 }
 

--- a/ui/src/components/StepDescription.jsx
+++ b/ui/src/components/StepDescription.jsx
@@ -27,7 +27,7 @@ function generatePersonList(list) {
     return list.map((person, i, array) => {
         let email = person.email && <a href={'mailto:' + person.email} style={{textDecoration:'none'}}> &#9993;</a>
         let comma = (i !== array.length - 1) && ',' // Comma will be inside link but the space outside the link.
-        let role = person.role && <span> ({person.role.reduce((r1, r2) => r1 + ", " + r2)})</span>
+        let role = person.role && <span> ({person.role.join(', ')})</span>
         if (person.identifier)
             return <span key={i}>
                 <a href={person.identifier} target="_blank">


### PR DESCRIPTION
Authors can now have roles, and the roles will be displayed beside their name in the UI. Partially closes #241 