### PR TITLE
Fixed various quirks and warnings found in the input form

### DIFF
--- a/ui/src/components/StepDescription.jsx
+++ b/ui/src/components/StepDescription.jsx
@@ -67,11 +67,10 @@ function generatePersonList(list) {
         </>
 
         let hoverCardName = person.name && <HoverCard popoverContent={hoverCardDisplay}>{person.name}</HoverCard>
-        return <><span key={i}>
-                  {
-                    (isAuthorProperties && hoverCardName) || <Typography style={{display: "inline"}}>{person.name}</Typography>
-                  }{comma}
-                </span> </>
+        return <span key={person.name + "-" + i}>
+            {(isAuthorProperties && hoverCardName) || <Typography style={{ display: "inline" }}>{person.name}</Typography>}
+            {comma}
+        </span>
 
     })
 }

--- a/ui/src/components/form/InputFileInput.jsx
+++ b/ui/src/components/form/InputFileInput.jsx
@@ -8,13 +8,14 @@ import ScriptInput from "./ScriptInput";
 
 import yaml from "js-yaml";
 import { isEmptyObject } from "../../utils/isEmptyObject";
-import Typography from "@mui/material/Typography";
+import _lang from "lodash/lang";
 import Box from "@mui/material/Box";
 import Tabs from "@mui/material/Tabs";
 import Tab from "@mui/material/Tab";
 import Alert from "@mui/material/Alert";
 
 import { styled } from "@mui/material";
+import { ScriptInputExample } from "./ScriptInputExample";
 
 /**
  * An input that we use to fill the input file's content.
@@ -143,26 +144,9 @@ const InputForm = ({ inputs, inputFileContent, setInputFileContent }) => {
                     size="medium"
                     keepWidth={true}
                   />
-                  {(!inputFileContent || inputFileContent[inputId] == "" || inputFileContent[inputId] == null)
-                    && example !== undefined
-                    && example !== null
-                    && (
-                      <Box>
-                        <Typography
-                          sx={{
-                            marginLeft: 2,
-                            fontFamily: "Roboto",
-                            fontSize: "0.75em",
-                            color: "#555",
-                          }}
-                        >
-                          <>
-                            Example:&nbsp;
-                            {typeof example.join === "function" ? example.join(", ") : example}
-                          </>
-                        </Typography>
-                      </Box>
-                    )}
+                  {!inputFileContent || !_lang.isEqual(inputFileContent[inputId], example)
+                    && <ScriptInputExample example={example} type={inputDescription.type} />
+                  }
                 </td>
                 <td className="descriptionCell">
                   {description ? (

--- a/ui/src/components/form/InputFileInput.jsx
+++ b/ui/src/components/form/InputFileInput.jsx
@@ -156,8 +156,10 @@ const InputForm = ({ inputs, inputFileContent, setInputFileContent }) => {
                             color: "#555",
                           }}
                         >
-                          Example:&nbsp;
-                          {typeof example.join === "function" ? example.join(", ") : example}
+                          <>
+                            Example:&nbsp;
+                            {typeof example.join === "function" ? example.join(", ") : example}
+                          </>
                         </Typography>
                       </Box>
                     )}

--- a/ui/src/components/form/InputFileInput.jsx
+++ b/ui/src/components/form/InputFileInput.jsx
@@ -164,10 +164,7 @@ const InputForm = ({ inputs, inputFileContent, setInputFileContent }) => {
                 </td>
                 <td className="descriptionCell">
                   {description ? (
-                    <ReactMarkdown
-                      className="reactMarkdown"
-                      children={description}
-                    />
+                    <ReactMarkdown className="reactMarkdown">{description}</ReactMarkdown>
                   ) : (
                     <Alert severity="warning">
                       Missing description for input "{inputId}"

--- a/ui/src/components/form/ScriptInput.jsx
+++ b/ui/src/components/form/ScriptInput.jsx
@@ -42,11 +42,11 @@ export default function ScriptInput({
   keepWidth,
   ...passedProps
 }) {
-  const [fieldValue, setFieldValue] = useState(value || "");
+  const [fieldValue, setFieldValue] = useState(value);
   const small = size == "small";
 
   useEffect(() => {
-    setFieldValue(value || "");
+    setFieldValue(value);
   }, [value]);
 
   if (!type) {
@@ -64,10 +64,11 @@ export default function ScriptInput({
         return { value: choice, label: choice };
       });
 
-      let value = fieldValue;
-      if(multiple) {
-        value = fieldValue ? optionObjects.filter((opt)=>fieldValue.includes(opt.value)) : []
-      }
+      let optionsValue;
+      if(multiple)
+        optionsValue = fieldValue ? optionObjects.filter((opt)=>fieldValue.includes(opt.value)) : []
+      else
+        optionsValue = fieldValue || ""
 
       return (
         <Autocomplete
@@ -112,7 +113,7 @@ export default function ScriptInput({
             },
           }}
           disabled={passedProps.disabled}
-          value={value}
+          value={optionsValue}
           onChange={(event, newOptions) => {
             var newValue;
             if (typeof newOptions.map === 'function') {
@@ -148,7 +149,7 @@ export default function ScriptInput({
         size={size}
         label={label}
         {...passedProps}
-        value={joinIfArray(fieldValue)}
+        value={joinIfArray(fieldValue) || ""}
         onChange={(e) => setFieldValue(e.target.value)}
         placeholder={ARRAY_PLACEHOLDER}
         cols={cols}
@@ -162,6 +163,8 @@ export default function ScriptInput({
 
   switch (type) {
     case "boolean":
+      const booleanValue = fieldValue === undefined || fieldValue === null ? false : value
+
       return (
         <FormGroup size={size}>
           <FormControlLabel
@@ -170,7 +173,7 @@ export default function ScriptInput({
                 type="checkbox"
                 size={size}
                 {...passedProps}
-                checked={fieldValue}
+                checked={booleanValue}
                 onChange={(e) => {
                   setFieldValue(e.target.checked);
                   onValueUpdated(e.target.checked);
@@ -191,7 +194,7 @@ export default function ScriptInput({
           variant="outlined"
           size={size}
           {...passedProps}
-          value={fieldValue}
+          value={fieldValue || ""}
           onChange={(e) => {
             setFieldValue(e.target.value);
             onValueUpdated(parseInt(e.target.value));
@@ -213,7 +216,7 @@ export default function ScriptInput({
           label={label}
           step="any"
           {...passedProps}
-          value={fieldValue}
+          value={fieldValue || ""}
           onChange={(e) => {
             setFieldValue(e.target.value);
             onValueUpdated(parseFloat(e.target.value));
@@ -237,7 +240,7 @@ export default function ScriptInput({
         );
 
       const props = {
-        value: fieldValue,
+        value: fieldValue || "",
         onChange: (e) => setFieldValue(e.target.value),
         placeholder: "null",
         onBlur: updateValue,

--- a/ui/src/components/form/ScriptInput.jsx
+++ b/ui/src/components/form/ScriptInput.jsx
@@ -64,6 +64,11 @@ export default function ScriptInput({
         return { value: choice, label: choice };
       });
 
+      let value = fieldValue;
+      if(multiple) {
+        value = fieldValue ? optionObjects.filter((opt)=>fieldValue.includes(opt.value)) : []
+      }
+
       return (
         <Autocomplete
           label={label}
@@ -107,11 +112,7 @@ export default function ScriptInput({
             },
           }}
           disabled={passedProps.disabled}
-          value={
-            multiple
-            ? fieldValue && optionObjects.filter((opt)=>fieldValue.includes(opt.value))
-            : fieldValue
-          }
+          value={value}
           onChange={(event, newOptions) => {
             var newValue;
             if (typeof newOptions.map === 'function') {

--- a/ui/src/components/form/ScriptInputExample.jsx
+++ b/ui/src/components/form/ScriptInputExample.jsx
@@ -4,7 +4,6 @@ export const ScriptInputExample = ({ example, type }) => {
     if (example === null || example === undefined)
         return null
 
-    // console.log(example)
     let exampleString
     if(typeof example.join === "function")
         exampleString = example.join(", ")

--- a/ui/src/components/form/ScriptInputExample.jsx
+++ b/ui/src/components/form/ScriptInputExample.jsx
@@ -1,0 +1,29 @@
+import { Box, Typography } from "@mui/material"
+
+export const ScriptInputExample = ({ example, type }) => {
+    if (example === null || example === undefined)
+        return null
+
+    // console.log(example)
+    let exampleString
+    if(typeof example.join === "function")
+        exampleString = example.join(", ")
+    else if(type === "boolean")
+        exampleString = example ? "true" : "false"
+    else
+        exampleString = example
+
+    return <Box>
+        <Typography
+            sx={{
+                marginLeft: 2,
+                fontFamily: "Roboto",
+                fontSize: "0.75em",
+                color: "#555",
+            }}
+        >
+            <>Example: {exampleString}</>
+        </Typography>
+    </Box>
+
+}


### PR DESCRIPTION
I cleared all the warnings visible in the protconn pipeline input form.
Fixed the display of examples. They now appear as soon as the value differs from the example.
Displaying boolean examples and array examples properly.

This does the same on the IO pane of the pipeline editor as well.