### PR TITLE
Check person.identifier not null before using

### DIFF
--- a/ui/src/components/StepDescription.jsx
+++ b/ui/src/components/StepDescription.jsx
@@ -63,7 +63,7 @@ function generatePersonList(list) {
             <hr />
             {email}
             {role && <p>Contribution: {role}</p> || <p></p>}
-            {identifierLogo ? null : <a href={person.identifier} target="_blank">{person.identifier.replace(/https?:\/\//, '')}</a>}
+            {identifierLogo ? null : <a href={person.identifier} target="_blank">{person.identifier?.replace(/https?:\/\//, '')}</a>}
         </>
 
         let hoverCardName = person.name && <HoverCard popoverContent={hoverCardDisplay}>{person.name}</HoverCard>


### PR DESCRIPTION
Species habitat index pipeline was crashing due to person.identifier not being defined for one of the authors. Must be checked before being used. [issue](https://github.com/GEO-BON/bon-in-a-box-pipeline-engine/blob/281aee3a63f3b73805c6d64c6d6b59f7e715c187/ui/src/components/StepDescription.jsx#L66)