### PR TITLE
Add the currently editing pipeline's name on top of the pipeline editor as a title

### DIFF
--- a/ui/src/Layout.css
+++ b/ui/src/Layout.css
@@ -800,7 +800,7 @@ h2.MuiDialogTitle-root {
 
   div.left-pane:has(.stepChooser) img#logo {
     max-width: 60px;
-    padding: 0 0 0 30px;
+    padding: 0 0 0 0px;
   }
 
   .previewMode {

--- a/ui/src/Layout.css
+++ b/ui/src/Layout.css
@@ -303,6 +303,10 @@ ul.pipeline-bullets li::before {
   color: hsl(0, 0%, 20%);
 }
 
+.react-flow__attribution.bottom.right {
+  border-bottom-right-radius: 10px;
+}
+
 .fullScreenPopup {
   position: absolute;
   top: 100px;
@@ -793,9 +797,13 @@ h2.MuiDialogTitle-root {
   button#saveBtn,
   button#saveAsBtn,
   button#loadFromFileBtn,
-  .stepChooser,
-  .pipelineTitle {
+  .stepChooser {
     display: none;
+  }
+
+  .pipelineTitle {
+    font-size: unset;
+    margin: 8px 0px;
   }
 
   div.left-pane:has(.stepChooser) img#logo {
@@ -805,15 +813,12 @@ h2.MuiDialogTitle-root {
 
   .previewMode {
     display: inline;
-  }
-
-  .previewMode p {
-    margin-block-start: 0.3em;
-    margin-block-end: 0.3em;
+    color: #555 !important;
+    border-bottom-left-radius: 10px;
   }
 
   div.right-content main {
-    padding: 0px 5px;
+    padding: 0px 10px;
   }
 
   .home-page-content {

--- a/ui/src/Layout.css
+++ b/ui/src/Layout.css
@@ -788,7 +788,7 @@ h2.MuiDialogTitle-root {
   button#saveAsBtn,
   button#loadFromFileBtn,
   .stepChooser,
-  .documentationLink {
+  .pipelineTitle {
     display: none;
   }
 
@@ -925,7 +925,7 @@ h2.MuiDialogTitle-root {
     display: none;
   }
 
-  .documentationLink,
+  .pipelineTitle,
   .previewMode {
     display: none;
   }

--- a/ui/src/Layout.css
+++ b/ui/src/Layout.css
@@ -818,7 +818,7 @@ h2.MuiDialogTitle-root {
   }
 
   div.right-content main {
-    padding: 0px 10px;
+    padding: 0px 5px;
   }
 
   .home-page-content {

--- a/ui/src/Layout.css
+++ b/ui/src/Layout.css
@@ -771,6 +771,12 @@ h2.MuiDialogTitle-root {
   display: none;
 }
 
+.pipelineTitle {
+  font-size: 1.25em;
+  color: white;
+  font-weight: 1000;
+}
+
 @media (max-width: 1100px) {
   .navigation-bar-link {
     margin-left: 10px;

--- a/ui/src/components/PipelineEditor/MetadataPane.jsx
+++ b/ui/src/components/PipelineEditor/MetadataPane.jsx
@@ -56,14 +56,18 @@ export const MetadataPane = ({
       if (model) {
         if (metadataError) {
           if (!isTyping) {
-            monaco.editor.setModelMarkers(model, "owner", [
-              {
-                startLineNumber: metadataError.line,
-                endColumn: model.getLineLength(metadataError.line) + 1,
-                message: metadataError.message,
-                severity: monaco.MarkerSeverity.Error
-              }
-            ]);
+            try {
+              monaco.editor.setModelMarkers(model, "owner", [
+                {
+                  startLineNumber: metadataError.line,
+                  endColumn: model.getLineLength(metadataError.line) + 1,
+                  message: metadataError.message,
+                  severity: monaco.MarkerSeverity.Error
+                }
+              ]);
+            } catch (ex) {
+              console.error("Error setting model markers:", ex);
+            }
           }
         } else {
           monaco.editor.setModelMarkers(model, "owner", []);

--- a/ui/src/components/PipelineEditor/PipelineEditor.jsx
+++ b/ui/src/components/PipelineEditor/PipelineEditor.jsx
@@ -64,6 +64,7 @@ const customNodeTypes = {
 };
 
 let id = 0;
+let metadataObj = null;
 const getId = () => `${id++}`;
 
 // Capture ctrl + s and ctrl + shift + s to quickly save the pipeline
@@ -866,6 +867,7 @@ export default function PipelineEditor(props) {
 
       // Read metadata
       setMetadata(flow.metadata ? yaml.dump(flow.metadata) : "")
+      metadataObj = flow.metadata || null;
 
       // Read inputs
       let inputsFromFile = [];
@@ -1077,11 +1079,19 @@ export default function PipelineEditor(props) {
     }
   }, [blocker.state])
 
+  const getPipelineTitle = () => {
+    if (metadataObj) {
+      if (metadataObj.name)
+        return metadataObj.name
+    }
+    return currentFileName
+  }
+
   return (
     <div id="editorLayout">
-      <p className="pipelineTitle">
-        {metadata ? yaml.load(metadata).name : currentFileName}
-      </p>
+      <h2 className="pipelineTitle">
+        {getPipelineTitle()}
+      </h2>
       <div className="narrowWarning">
         <p>The pipeline engine cannot be used on a narrow display.</p>
         <p><strong>A computer is recommended for pipeline edition.</strong></p>

--- a/ui/src/components/PipelineEditor/PipelineEditor.jsx
+++ b/ui/src/components/PipelineEditor/PipelineEditor.jsx
@@ -1102,10 +1102,6 @@ export default function PipelineEditor(props) {
         <p>A phone can be used horizontally to preview a pipeline.</p>
       </div>
 
-      <div className="previewMode">
-        <p>Currently in <strong>preview mode</strong>. Use a larger screen to edit.</p>
-      </div>
-
       <Dialog
         open={modal === 'saveAs'}
         onClose={() => hideModal('saveAs')}
@@ -1331,6 +1327,10 @@ export default function PipelineEditor(props) {
                   }
                 }}
               />
+
+              <div class="react-flow__attribution bottom left previewMode">
+                  Currently in <strong>preview mode</strong>. Use a larger screen to edit.
+              </div>
             </ReactFlow>
           </div>
         </ReactFlowProvider>

--- a/ui/src/components/PipelineEditor/PipelineEditor.jsx
+++ b/ui/src/components/PipelineEditor/PipelineEditor.jsx
@@ -1079,7 +1079,6 @@ export default function PipelineEditor(props) {
   }, [blocker.state])
 
   useEffect(() => {
-    console.debug("Metadata changed", metadata);
     try {
       const metadataObj = yaml.load(metadata)
       if (metadataObj && metadataObj.name) {
@@ -1088,7 +1087,6 @@ export default function PipelineEditor(props) {
         setTitle(currentFileName || <>&nbsp;</>);
       }
     } catch (ex) {
-      console.error("Invalid YAML metadata", ex);
       // keep previous title. It's OK for YAML to be temporary invalid.
     }
   }, [metadata]);

--- a/ui/src/components/PipelineEditor/PipelineEditor.jsx
+++ b/ui/src/components/PipelineEditor/PipelineEditor.jsx
@@ -1079,15 +1079,8 @@ export default function PipelineEditor(props) {
 
   return (
     <div id="editorLayout">
-      <p className="documentationLink">
-        Need help? Check out{" "}
-        <a
-          href="https://geo-bon.github.io/bon-in-a-box-pipeline-engine/how_to_contribute.html#step-5-connect-your-scripts-with-the-bon-in-a-box-pipeline-editor"
-          target="_blank"
-          rel="noreferrer"
-        >
-          the documentation
-        </a>
+      <p className="pipelineTitle">
+        {metadata ? yaml.load(metadata).name : currentFileName}
       </p>
       <div className="narrowWarning">
         <p>The pipeline engine cannot be used on a narrow display.</p>

--- a/ui/src/components/PipelineEditor/PipelineEditor.jsx
+++ b/ui/src/components/PipelineEditor/PipelineEditor.jsx
@@ -64,7 +64,6 @@ const customNodeTypes = {
 };
 
 let id = 0;
-let metadataObj = null;
 const getId = () => `${id++}`;
 
 // Capture ctrl + s and ctrl + shift + s to quickly save the pipeline
@@ -95,6 +94,7 @@ export default function PipelineEditor(props) {
   const [inputList, setInputList] = useState([]);
   const [outputList, setOutputList] = useState([]);
   const [metadata, setMetadata] = useState("");
+  const [title, setTitle] = useState(<>&nbsp;</>);
   const [metadataError, setMetadataError] = useState(null);
   const [currentFileName, setCurrentFileName] = useState("");
   const [savedJSON, setSavedJSON] = useState(null);
@@ -867,7 +867,6 @@ export default function PipelineEditor(props) {
 
       // Read metadata
       setMetadata(flow.metadata ? yaml.dump(flow.metadata) : "")
-      metadataObj = flow.metadata || null;
 
       // Read inputs
       let inputsFromFile = [];
@@ -1079,18 +1078,25 @@ export default function PipelineEditor(props) {
     }
   }, [blocker.state])
 
-  const getPipelineTitle = () => {
-    if (metadataObj) {
-      if (metadataObj.name)
-        return metadataObj.name
+  useEffect(() => {
+    console.debug("Metadata changed", metadata);
+    try {
+      const metadataObj = yaml.load(metadata)
+      if (metadataObj && metadataObj.name) {
+        setTitle(metadataObj.name);
+      } else {
+        setTitle(currentFileName || <>&nbsp;</>);
+      }
+    } catch (ex) {
+      console.error("Invalid YAML metadata", ex);
+      // keep previous title. It's OK for YAML to be temporary invalid.
     }
-    return currentFileName
-  }
+  }, [metadata]);
 
   return (
     <div id="editorLayout">
       <h2 className="pipelineTitle">
-        {getPipelineTitle()}
+        {title}
       </h2>
       <div className="narrowWarning">
         <p>The pipeline engine cannot be used on a narrow display.</p>


### PR DESCRIPTION
Make it more clear to the user of the currently being edited pipeline without needing to open the metadata pane. closes #268