### PR TITLE
Handling missing scripts

### DIFF
--- a/ui/src/components/Lifecycle.jsx
+++ b/ui/src/components/Lifecycle.jsx
@@ -36,6 +36,8 @@ function ChipFromStatus({ status }) {
       chipStyle.backgroundColor = '#c7a9ff';
       displayText = "Example";
       break;
+    case 'none': // used when script not found on server
+      return null;
     default:
       console.warn(`Unknown lifecycle status: ${status}`);
   }

--- a/ui/src/components/PipelineResults.jsx
+++ b/ui/src/components/PipelineResults.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 import { StepResult, SingleIOResult } from "./StepResult";
 import {
   FoldableOutput,
@@ -25,7 +25,7 @@ import {
   GeneralDescription,
 } from "./StepDescription";
 import { getScript } from "../utils/IOId";
-import { api } from "./PipelinePage";
+import { fetchStepDescriptionAsync } from "./PipelineEditor/StepDescriptionStore";
 
 export function PipelineResults({
   pipelineMetadata,
@@ -98,7 +98,7 @@ export function PipelineResults({
                       value = inputFileContent[breadcrumbs];
                     }
 
-                                                    
+
                     if (!value) {
                       let noValueStatus = null;
                       if (/pipeline@\d+|default_output/.test(ioId)) {
@@ -228,7 +228,6 @@ export function DelayedResult({
     // Execute only when folder changes (omitting resultData on purpose)
   }, [folder]);
 
-  
 
   const interval = useInterval(
     () => {
@@ -254,8 +253,8 @@ export function DelayedResult({
           });
         }
       }
-      
-      
+
+
       // Fetch the output
       fetch("/output/" + folder + "/output.json?t=" + displayTimeStamp)
         .then((response) => {
@@ -313,12 +312,15 @@ export function DelayedResult({
   );
 
   useEffect(() => {
-    // Script metadata
-    var callback = function (error, data, response) {
-      setScriptMetadata(data);
-    };
-
-    api.getInfo("script", script, callback);
+    console.log("Fetching metadata for ", script);
+    fetchStepDescriptionAsync(script)
+      .then((data) => {
+        if(data) {
+          setScriptMetadata(data);
+        } else {
+          setScriptMetadata({});
+        }
+      })
   }, [script]);
 
   let inputsContent,
@@ -340,7 +342,7 @@ export function DelayedResult({
       );
     }
 
-    
+
     if (outputData) {
       outputsContent = (
         <StepResult
@@ -349,7 +351,7 @@ export function DelayedResult({
           sectionName="output"
         />
       );
-      
+
       environmentContent = (
         <FoldableOutput title="Environment" className="stepEnvironment">
           <EnvironmentInfo folder={folder}/>
@@ -359,7 +361,7 @@ export function DelayedResult({
       icon = (
         <>
           {outputData.error && <Error color="error" />}
-          {outputData.warning && <Warning color="warning" />}
+          {(outputData.warning || isEmptyObject(scriptMetadata)) && <Warning color="warning" />}
           {outputData.info && <Info color="info" />}
         </>
       );

--- a/ui/src/components/StepDescription.jsx
+++ b/ui/src/components/StepDescription.jsx
@@ -5,6 +5,8 @@ import Typography from "@mui/material/Typography";
 import LinkedinLogo from "../img/LinkedIn_icon.svg";
 import ResearchGateLogo from "../img/ResearchGate_icon.svg";
 import OrcIDLogo from "../img/ORCID_ID_green.svg";
+import { isEmptyObject } from '../utils/isEmptyObject';
+import { Alert } from '@mui/material';
 
 export function StepDescription({ descriptionFile, metadata }) {
     return <>
@@ -85,6 +87,13 @@ function generatePersonList(list) {
 export function GeneralDescription({ ymlPath, metadata }) {
     if (!metadata)
         return null
+
+    console.log("GeneralDescription metadata:", metadata)
+    if (isEmptyObject(metadata)) {
+        return <div className='stepDescription'>
+            <Alert severity='warning'>Script was not found on this server. Raw results will be displayed.</Alert>
+        </div>
+    }
 
     const codeLink = getCodeUrl(ymlPath, metadata.script)
 


### PR DESCRIPTION
When loading old results :
Before, is would write "Waiting for other scripts to complete" if script yml file was missing (for example renamed).
Now, it displays appropriate error message.