### PR TITLE
Best docker install practices

### DIFF
--- a/python-api/Dockerfile
+++ b/python-api/Dockerfile
@@ -3,8 +3,11 @@ ARG TITILER_VERSION=0.18.9
 
 FROM ghcr.io/developmentseed/titiler:${TITILER_VERSION} AS builder
 
-RUN apt update
-RUN apt install -y libgdal-dev
+RUN set -ex; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends libgdal-dev; \
+    apt-get clean all; \
+    rm -rf /var/lib/apt/lists/*
 RUN pip install uv
 
 ENV VIRTUAL_ENV=/opt/venv

--- a/script-server/Dockerfile.dev
+++ b/script-server/Dockerfile.dev
@@ -15,6 +15,7 @@ RUN chmod 755 /usr/local/bin/docker
 RUN set -ex; \
     apt-get update; \
     apt-get install -y --no-install-recommends python3 libc6-dev; \
-    apt-get clean all;
+    apt-get clean all; \
+    rm -rf /var/lib/apt/lists/*
 
 RUN echo "dev" > /version.txt


### PR DESCRIPTION
- “apt-get is preferred for use in scripts.”
- Apparently /var/lib/apt/lists/ is not removed by clean.