### PR TITLE
Options to text type conversion

### DIFF
--- a/docs_source/how_to_contribute.qmd
+++ b/docs_source/how_to_contribute.qmd
@@ -105,15 +105,23 @@ Specifying an example will auto-fill that input with the example unless changed 
 
 There are several different types of user inputs that can be specified in the YAML file:
 
++----------------------------------+----------------------------+-----------------------------------------------------------------------------------+
 | "Type" attribute in the yaml     | UI rendering               | Description                                                                       |
-|------------------------|------------------------|------------------------|
++==================================+============================+===================================================================================+
 | boolean                          | Plain text                 | true/false                                                                        |
++----------------------------------+----------------------------+-----------------------------------------------------------------------------------+
 | float or float\[\] (float array) | Plain text                 | positive or negative numbers with a decimal point, accepts int and a valid input. |
++----------------------------------+----------------------------+-----------------------------------------------------------------------------------+
 | int or int\[\] (int array)       | Plain text                 | integer                                                                           |
++----------------------------------+----------------------------+-----------------------------------------------------------------------------------+
 | options^1^                       | Dropdown menu              | Select one from predefined options                                                |
++----------------------------------+----------------------------+-----------------------------------------------------------------------------------+
 | options\[\]^1^                   | Multi-select dropdown menu | Select several from predefined options                                            |
++----------------------------------+----------------------------+-----------------------------------------------------------------------------------+
 | text or text\[\] (text array)    | Plain text                 | text input (words)                                                                |
++----------------------------------+----------------------------+-----------------------------------------------------------------------------------+
 | (any unknown type)               | Plain text                 |                                                                                   |
++----------------------------------+----------------------------+-----------------------------------------------------------------------------------+
 
 -   Note that the square brackets specify an array, where the user can input multiple values separated by a comma. This is useful if you want the analysis to run with several different parameters (e.g. for multiple species or with multiple raster bands).
 
@@ -133,15 +141,23 @@ options_example:
 
 The user inputs can also be file types if you want to upload a file or connect the script to a previous one that outputs a specific file type. There are several file types that you can specify:
 
-| File Type  | MIME type to use in the yaml   | Description                                                               |
-|------------------|----------------------------|--------------------------|
-| CSV        | text/csv                       | Comma separated values file format (.csv)                                 |
-| GeoJSON    | application/geo+json           | GeoJSON file format (.geojson)                                            |
-| GeoPackage | application/geopackage+sqlite3 | GeoPackage file format (.gpkg)                                            |
-| GeoTIFF^2^ | image/tiff;application=geotiff | GeoTIFF file format (.tif)                                                |
-| Shapefile  | application/dbf                | Shapefile format (.shp)                                                   |
-| Text       | text/plain                     | Plain text output (no need to save as a format just output in the script) |
-| TSV        | text/tab-separated-values      | Tab separated values format (.tsv)                                        |
++----------------+--------------------------------+---------------------------------------------------------------------------+
+| File Type      | MIME type to use in the yaml   | Description                                                               |
++================+================================+===========================================================================+
+| CSV            | text/csv                       | Comma separated values file format (.csv)                                 |
++----------------+--------------------------------+---------------------------------------------------------------------------+
+| GeoJSON        | application/geo+json           | GeoJSON file format (.geojson)                                            |
++----------------+--------------------------------+---------------------------------------------------------------------------+
+| GeoPackage     | application/geopackage+sqlite3 | GeoPackage file format (.gpkg)                                            |
++----------------+--------------------------------+---------------------------------------------------------------------------+
+| GeoTIFF^2^     | image/tiff;application=geotiff | GeoTIFF file format (.tif)                                                |
++----------------+--------------------------------+---------------------------------------------------------------------------+
+| Shapefile      | application/dbf                | Shapefile format (.shp)                                                   |
++----------------+--------------------------------+---------------------------------------------------------------------------+
+| Text           | text/plain                     | Plain text output (no need to save as a format just output in the script) |
++----------------+--------------------------------+---------------------------------------------------------------------------+
+| TSV            | text/tab-separated-values      | Tab separated values format (.tsv)                                        |
++----------------+--------------------------------+---------------------------------------------------------------------------+
 
 For example:
 
@@ -161,13 +177,19 @@ inputs:
 
 The input type can also be set to a limited number of keywords that will automatically generate standardized selectors adapted for the input type. For example, specifying 'country' as input type will create a dropdown menu with a standardized list of countries from GeoNames. Selecting 'bboxCRS' will allow the user to define a bounding box from a country or by clicking on a map. Here is the current list of available selectors:
 
-| Input name       | Description                                                                                                                                                                                                                                                       |     |
-|------------------|----------------------------|--------------------------|
-| country          | Creates a selector (drop down menu) with a standardized list of countries. GeoNames is used as the reference for the country list.                                                                                                                                |     |
-| countryRegion    | Creates a selector (drop down menu) with a standardized list of regions (provinces, states, etc) within a selected country. GeoNames is used as the reference for the list of regions.                                                                            |     |
-| countryRegionCRS | Creates a selector (drop down menu) for choosing a coordinate reference system adapted for a specific country and/or region.                                                                                                                                      |     |
-| CRS              | Creates a selector for specifying a coordinate reference system.                                                                                                                                                                                                  |     |
-| bboxCRS          | Creates a button to open an interface that allows the user to specify a bounding box (geographical minima and maxima) based on an optional selection of country/region and on a CRS, or by clicking on the map to set the bounds of the area of interest for the analysis. |     |
++------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------+
+| Input name       | Description                                                                                                                                                                                                                                                                |                        |
++==================+============================================================================================================================================================================================================================================================================+========================+
+| country          | Creates a selector (drop down menu) with a standardized list of countries. GeoNames is used as the reference for the country list.                                                                                                                                         |                        |
++------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------+
+| countryRegion    | Creates a selector (drop down menu) with a standardized list of regions (provinces, states, etc) within a selected country. GeoNames is used as the reference for the list of regions.                                                                                     |                        |
++------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------+
+| countryRegionCRS | Creates a selector (drop down menu) for choosing a coordinate reference system adapted for a specific country and/or region.                                                                                                                                               |                        |
++------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------+
+| CRS              | Creates a selector for specifying a coordinate reference system.                                                                                                                                                                                                           |                        |
++------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------+
+| bboxCRS          | Creates a button to open an interface that allows the user to specify a bounding box (geographical minima and maxima) based on an optional selection of country/region and on a CRS, or by clicking on the map to set the bounds of the area of interest for the analysis. |                        |
++------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------+
 
 Note that the use of these selectors will create objects that contain multiple elements. For example, the country selector will create an input object that contains the country name in English, the ISO3 code of the country, the ISO2 code, as well as the bounding box of that country, in longitude, latitude coordinates. [See the full list of those keys for each selector here](selectors.qmd).
 
@@ -177,18 +199,29 @@ After specifying the inputs, you can specify the files that you want to output f
 
 There are also several types of outputs that can be created
 
-| File Type  | MIME type to use in the yaml   | UI rendering                 |
-|------------|--------------------------------|------------------------------|
-| CSV        | text/csv                       | HTML table (partial content) |
-| GeoJSON^2^ | application/geo+json           | Map                          |
-| GeoPackage | application/geopackage+sqlite3 | Link                         |
-| GeoTIFF^3^ | image/tiff;application=geotiff | Map widget (leaflet)         |
-| HTML       | text/html                      | Open in new tab              |
-| JPG        | image/jpg                      | tag                          |
-| Shapefile  | application/dbf                | Link                         |
-| Text       | text/plain                     | Plain text                   |
-| TSV        | text/tab-separated-values      | HTML table (partial content) |
-|            | (any unknown type)             | Plain text or link           |
++--------------+--------------------------------+------------------------------+
+| File Type    | MIME type to use in the yaml   | UI rendering                 |
++==============+================================+==============================+
+| CSV          | text/csv                       | HTML table (partial content) |
++--------------+--------------------------------+------------------------------+
+| GeoJSON^2^   | application/geo+json           | Map                          |
++--------------+--------------------------------+------------------------------+
+| GeoPackage   | application/geopackage+sqlite3 | Link                         |
++--------------+--------------------------------+------------------------------+
+| GeoTIFF^3^   | image/tiff;application=geotiff | Map widget (leaflet)         |
++--------------+--------------------------------+------------------------------+
+| HTML         | text/html                      | Open in new tab              |
++--------------+--------------------------------+------------------------------+
+| JPG          | image/jpg                      | tag                          |
++--------------+--------------------------------+------------------------------+
+| Shapefile    | application/dbf                | Link                         |
++--------------+--------------------------------+------------------------------+
+| Text         | text/plain                     | Plain text                   |
++--------------+--------------------------------+------------------------------+
+| TSV          | text/tab-separated-values      | HTML table (partial content) |
++--------------+--------------------------------+------------------------------+
+|              | (any unknown type)             | Plain text or link           |
++--------------+--------------------------------+------------------------------+
 
 ^2^ GeoJSON coordinates *must* be in WGS 84. See [specification section 4](https://datatracker.ietf.org/doc/html/rfc7946#section-4) for details.
 
@@ -481,7 +514,6 @@ crs_id <- paste0(input$study_area_bbox$CRS$authority,input$study_area_bbox$CRS$c
 :::
 
 ::: panel-tabset
-
 ## Python
 
 A convenience function `biab_inputs` is loaded in Python by default to load the file into a list. Here is an example of how to read the input file in the script and use it's value:
@@ -495,7 +527,7 @@ my_int = data['some_int_input']
 To access selector values in Python, the approach is similar to R. For example, to create the CRS ID from the authority and code:
 :::
 
-::: panel-tabset
+:::: panel-tabset
 ``` python
 crs_id = data['study_area_bbox']['CRS']['authority']+':'+str(data['study_area_bbox']['CRS']['code'])
 ```
@@ -523,7 +555,7 @@ To access selector values in Julia, the approach is similar to R or Python. For 
 ``` julia
 crs_id = string(input_data["study_area_bbox"]["CRS"]["authority"],":",input_data["study_area_bbox"]["CRS"]["code"])
 ```
-:::
+::::
 
 ### Writing outputs
 
@@ -731,14 +763,12 @@ In most cases, an output can only receive a value of the exact same type. This m
 
 +---------------+-----------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
 | # Source type | # Target type         | # Example                                                                                                                                   |
-|               |                       |                                                                                                                                             |
-| Any type      | An array of that type | An array of GeoTIFFs receives a single GeoTIFF.                                                                                             |
-|               |                       |                                                                                                                                             |
-|               |                       | `layer.tiff` becomes \`\[layer.tiff\]                                                                                                       |
 +---------------+-----------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
+| Any type      | An array of that type | When an array of GeoTIFFs is expected, a single GeoTIFF which is automatically wrapped in a single-element array.                           |
 |               |                       |                                                                                                                                             |
+|               |                       | `layer.tiff` becomes `[layer.tiff]`                                                                                                         |
 +---------------+-----------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
-| int           | float                 | A buffer in kilometers received as an int by one script and as a float by another can share the same user input. \| \| `1` becomes `1.0` \| |
+| int           | float                 | A buffer in kilometers received as an int by one script and as a float by another can share the same user input. `1` becomes `1.0`          |
 +---------------+-----------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
 | options       | text                  | A script receiving a link to any geospatial collection on a STAC as a string can be restricted at pipeline level to a few selected options. |
 +---------------+-----------------------+---------------------------------------------------------------------------------------------------------------------------------------------+

--- a/docs_source/how_to_contribute.qmd
+++ b/docs_source/how_to_contribute.qmd
@@ -70,7 +70,7 @@ YAML files should begin with a name, description, and the authors of the script.
 
 Example:
 
-```         
+```
 script: script_name.R
 name: Script Name
 description: Describe what the script does
@@ -87,7 +87,7 @@ All input and output ids should follow the snake case naming conventions. Names 
 
 Here is an example where the inputs are a coordinate reference system and a distance, specified by the user:
 
-```         
+```
 inputs:
   crs:
     label: coordinate reference system for output
@@ -119,7 +119,7 @@ There are several different types of user inputs that can be specified in the YA
 
 ^1^options type requires an additional options attribute to be added with the available options.
 
-```         
+```
 options_example:
   label: Options example
   description: The user has to select between a fixed number of text options. Also called select or enum. The script receives the selected option as text.
@@ -145,7 +145,7 @@ The user inputs can also be file types if you want to upload a file or connect t
 
 For example:
 
-```         
+```
 inputs:
   landcover_raster:
     label: Raster of landcover
@@ -194,7 +194,7 @@ There are also several types of outputs that can be created
 
 ^3^ When used as an output, `image/tiff;application=geotiff` type allows an additional `range` attribute to be added with the min and max values that the tiff should hold. This will be used for display purposes.
 
-```         
+```
 map:
   label: My map
   description: Some map that shows something
@@ -205,7 +205,7 @@ map:
 
 Here is an example output:
 
-```         
+```
 outputs:
   result:
     label: Analysis result
@@ -242,7 +242,7 @@ Search for your package names on [anaconda](https://anaconda.org/). Packages tha
 
 Example of conda sub-environment for an R script:
 
-```         
+```
 conda: # Optional: if you script requires specific versions of packages.
   channels:
     - conda-forge # make sure to put conda forge first
@@ -258,7 +258,7 @@ conda: # Optional: if you script requires specific versions of packages.
 
 Example of conda sub-environment for a python script. You do not need to put anything after conda-forge or before the package names when specifying a conda environment for python.
 
-```         
+```
 conda:
   channels:
     - conda-forge
@@ -282,7 +282,7 @@ For more information, refer to the [conda documentation](https://docs.conda.io/p
 
 #### Full example of a YAML file:
 
-```         
+```
 script: script_name.R
 name: Script Name
 description: Describe what the script does
@@ -343,7 +343,7 @@ If inputs are outputs from a previous step in the pipeline, make sure to give th
 
 #### Empty commented template to fill in:
 
-```         
+```
 script: # script file with extension, such as "myScript.R".
 name: # short name, such as My Script
 description: # Targeted to those who will interpret pipeline results and edit pipelines.
@@ -476,7 +476,7 @@ bbox <- input$study_area_bbox$bbox
 and the ID of the coordinate reference system of the bounding box, made of the authority and code:
 
 ``` r
-crs_id <- paste0(input$study_area_bbox$CRS$authority,input$study_area_bbox$CRS$code) 
+crs_id <- paste0(input$study_area_bbox$CRS$authority,input$study_area_bbox$CRS$code)
 ```
 :::
 
@@ -724,6 +724,24 @@ Then, use the down arrow to pop the node's menu. Choose "Convert to user input".
 The node will change as shown below, and the details will appear on the right pane, along with the other user inputs.
 
 <img src="https://user-images.GitHubusercontent.com/6223744/218197580-d5e21247-0492-40d7-b527-add323abd6b4.png" height="51"/>
+
+#### Input type conversions
+
+In most cases, an output can only receive a value of the exact same type. This means that if you plug an output of type "text/csv" to an input of type "float", the system will display an error when saving the pipeline. However, there are exceptions where type conversions are allowed:
+
++---------------+-----------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
+| # Source type | # Target type         | # Example                                                                                                                                   |
+|               |                       |                                                                                                                                             |
+| Any type      | An array of that type | An array of GeoTIFFs receives a single GeoTIFF.                                                                                             |
+|               |                       |                                                                                                                                             |
+|               |                       | `layer.tiff` becomes \`\[layer.tiff\]                                                                                                       |
++---------------+-----------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
+|               |                       |                                                                                                                                             |
++---------------+-----------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
+| int           | float                 | A buffer in kilometers received as an int by one script and as a float by another can share the same user input. \| \| `1` becomes `1.0` \| |
++---------------+-----------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
+| options       | text                  | A script receiving a link to any geospatial collection on a STAC as a string can be restricted at pipeline level to a few selected options. |
++---------------+-----------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
 
 ### Pipeline inputs and outputs
 

--- a/script-server/src/main/kotlin/org/geobon/pipeline/Output.kt
+++ b/script-server/src/main/kotlin/org/geobon/pipeline/Output.kt
@@ -10,10 +10,11 @@ class Output(override val type:String) : Pipe {
         }
 
     fun getId():IOId {
-        step?.let { step ->
+        return step?.let { step ->
             val entry = step.outputs.entries.find { it.value == this }
                 ?: throw RuntimeException("Could not find id for output of type $type in step $step")
-            return IOId(step.id, entry.key)
+
+            IOId(step.id, entry.key)
         } ?: throw RuntimeException("Output of type $type disconnected from any step when calling findId()")
     }
 

--- a/script-server/src/main/kotlin/org/geobon/pipeline/Pipeline.kt
+++ b/script-server/src/main/kotlin/org/geobon/pipeline/Pipeline.kt
@@ -340,8 +340,8 @@ open class Pipeline constructor(
             val inputsParsed = JSONObject(inputsString)
             val constants = mutableMapOf<String, Pipe>()
             inputsParsed.keySet().forEach { key ->
-                val type = step.inputsDefinition[key]
-                    ?: throw RuntimeException("Input received \"$key\" is not listed in script inputs. Listed inputs are ${step.inputsDefinition.keys}")
+                val type = step.inputTypes[key]
+                    ?: throw RuntimeException("Input received \"$key\" is not listed in script inputs. Listed inputs are ${step.inputTypes.keys}")
 
                 val inputId = IOId(step.id, key)
                 constants[inputId.toBreadcrumbs()] = createConstant(key, inputsParsed, type, key)

--- a/script-server/src/main/kotlin/org/geobon/pipeline/YMLStep.kt
+++ b/script-server/src/main/kotlin/org/geobon/pipeline/YMLStep.kt
@@ -6,6 +6,7 @@ import org.geobon.script.Description.NAME
 import org.geobon.script.Description.OUTPUTS
 import org.geobon.script.Description.TYPE
 import org.geobon.script.Description.TYPE_OPTIONS
+import org.geobon.script.Description.TYPE_TEXT
 import org.geobon.script.ScriptRun
 import org.json.JSONObject
 import org.slf4j.Logger
@@ -28,7 +29,7 @@ abstract class YMLStep(
      */
     protected var context:RunContext? = null
 
-    val inputsDefinition = readInputs(yamlParsed, logger)
+    val inputTypes = readInputTypes(yamlParsed, logger)
     override fun getDisplayBreadcrumbs(): String {
         return if (yamlParsed.containsKey(NAME)) "\"${yamlParsed[NAME]}\" (${id.toBreadcrumbs()})"
         else id.toBreadcrumbs()
@@ -36,17 +37,17 @@ abstract class YMLStep(
 
     override fun validateInputsConfiguration(): String {
 
-        if (inputs.size != inputsDefinition.size) {
+        if (inputs.size != inputTypes.size) {
             return "Bad number of inputs." +
-                    "\n\tYAML spec: ${inputsDefinition.keys}" +
+                    "\n\tYAML spec: ${inputTypes.keys}" +
                     "\n\tReceived:  ${inputs.keys}" +
-                    "\n\tExtra keys: ${inputs.mapNotNull { if (inputsDefinition.containsKey(it.key)) null else it.key }}" +
-                    "\n\tMissing keys: ${inputsDefinition.mapNotNull { if (inputs.containsKey(it.key)) null else it.key }}\n"
+                    "\n\tExtra keys: ${inputs.mapNotNull { if (inputTypes.containsKey(it.key)) null else it.key }}" +
+                    "\n\tMissing keys: ${inputTypes.mapNotNull { if (inputs.containsKey(it.key)) null else it.key }}\n"
         }
 
         // Validate presence and type of each input
         var errorMessages = ""
-        inputsDefinition.forEach { (inputKey, expectedType) ->
+        inputTypes.forEach { (inputKey, expectedType) ->
             errorMessages += inputs[inputKey]?.let {inputPipe ->
                 if (inputPipe.type == expectedType) ""
                 // Check for type conversions
@@ -55,7 +56,7 @@ abstract class YMLStep(
                     inputPipe.type == "int" && expectedType == "float" -> ""
 
                     // options to text accepted
-                    inputPipe.type == TYPE_OPTIONS && expectedType == "text" -> ""
+                    inputPipe.type == TYPE_OPTIONS && expectedType == TYPE_TEXT -> ""
 
                     // Non-array to single-element array accepted
                     expectedType.endsWith("[]") && inputPipe.type == expectedType.dropLast(2) -> {
@@ -72,7 +73,7 @@ abstract class YMLStep(
                         "Wrong type for input $displayName: expected \"$expectedType\" but \"${inputPipe.type}\" was received.\n"
                     }
                 }
-            } ?: "Missing key $inputKey\n\tYAML spec: ${inputsDefinition.keys}\n\tReceived:  ${inputs.keys}\n"
+            } ?: "Missing key $inputKey\n\tYAML spec: ${inputTypes.keys}\n\tReceived:  ${inputs.keys}\n"
         }
 
         return errorMessages
@@ -84,11 +85,13 @@ abstract class YMLStep(
 
         try { // Validation
             inputs.filter { (_, pipe) -> pipe.type == TYPE_OPTIONS }.forEach { (key, _) ->
-                val options = readIODescription(INPUTS, key)?.get(TYPE_OPTIONS) as? List<*>
-                    ?: throw RuntimeException("$yamlFile: No options found for input parameter $key.")
+                if(inputTypes[key] != TYPE_TEXT) { // Ignore options to text conversion
+                    val options = readIODescription(INPUTS, key)?.get(TYPE_OPTIONS) as? List<*>
+                        ?: throw RuntimeException("$yamlFile: No options found for input parameter $key.")
 
-                if (!options.contains(resolvedInputs[key])) {
-                    throw RuntimeException("$yamlFile: Received value ${resolvedInputs[key]} not in options $options.")
+                    if (!options.contains(resolvedInputs[key])) {
+                        throw RuntimeException("$yamlFile: Received value ${resolvedInputs[key]} not in options $options.")
+                    }
                 }
             }
         } catch (e:RuntimeException) {
@@ -142,7 +145,7 @@ abstract class YMLStep(
         /**
          * @return Map of input name to type
          */
-        private fun readInputs(yamlParsed: Map<String, Any>, logger: Logger): Map<String, String> {
+        private fun readInputTypes(yamlParsed: Map<String, Any>, logger: Logger): Map<String, String> {
             val inputs = mutableMapOf<String, String>()
             readIO(yamlParsed, INPUTS, logger) { key, type ->
                 inputs[key] = type

--- a/script-server/src/main/kotlin/org/geobon/pipeline/YMLStep.kt
+++ b/script-server/src/main/kotlin/org/geobon/pipeline/YMLStep.kt
@@ -47,16 +47,19 @@ abstract class YMLStep(
         // Validate presence and type of each input
         var errorMessages = ""
         inputsDefinition.forEach { (inputKey, expectedType) ->
-            errorMessages += inputs[inputKey]?.let {
-                if (it.type == expectedType) ""
-                // Check for convertible types (currently only int to float, use a map/when if more conversions are possible)
+            errorMessages += inputs[inputKey]?.let {inputPipe ->
+                if (inputPipe.type == expectedType) ""
+                // Check for type conversions
                 else when {
                     // int to float accepted
-                    it.type == "int" && expectedType == "float" -> ""
+                    inputPipe.type == "int" && expectedType == "float" -> ""
+
+                    // options to text accepted
+                    inputPipe.type == TYPE_OPTIONS && expectedType == "text" -> ""
 
                     // Non-array to single-element array accepted
-                    expectedType.endsWith("[]") && it.type == expectedType.dropLast(2) -> {
-                        inputs[inputKey] = AggregatePipe(listOf(it))
+                    expectedType.endsWith("[]") && inputPipe.type == expectedType.dropLast(2) -> {
+                        inputs[inputKey] = AggregatePipe(listOf(inputPipe))
                         ""
                     }
 
@@ -64,9 +67,9 @@ abstract class YMLStep(
                     else -> {
                         val description = readIODescription(INPUTS, inputKey)
                         val label = description?.get(LABEL) as? String?
-                        var displayName = if (label != null) "\"$label\" ($inputKey)" else inputKey
+                        val displayName = if (label != null) "\"$label\" ($inputKey)" else inputKey
 
-                        "Wrong type for input $displayName: expected \"$expectedType\" but \"${it.type}\" was received.\n"
+                        "Wrong type for input $displayName: expected \"$expectedType\" but \"${inputPipe.type}\" was received.\n"
                     }
                 }
             } ?: "Missing key $inputKey\n\tYAML spec: ${inputsDefinition.keys}\n\tReceived:  ${inputs.keys}\n"

--- a/script-server/src/main/kotlin/org/geobon/pipeline/YMLStep.kt
+++ b/script-server/src/main/kotlin/org/geobon/pipeline/YMLStep.kt
@@ -90,7 +90,7 @@ abstract class YMLStep(
                         ?: throw RuntimeException("$yamlFile: No options found for input parameter $key.")
 
                     if (!options.contains(resolvedInputs[key])) {
-                        throw RuntimeException("$yamlFile: Received value ${resolvedInputs[key]} not in options $options.")
+                        throw RuntimeException("$yamlFile: Received value ${resolvedInputs[key]} as ${resolvedInputs[key]?.javaClass?.simpleName} not in options $options as ${options.first()?.javaClass?.simpleName}.")
                     }
                 }
             }

--- a/script-server/src/main/kotlin/org/geobon/script/Description.kt
+++ b/script-server/src/main/kotlin/org/geobon/script/Description.kt
@@ -16,6 +16,7 @@ object Description {
     const val LABEL = "label"
     const val TYPE = "type"
     const val TYPE_OPTIONS = "options"
+    const val TYPE_TEXT = "text"
 
     const val CONDA = "conda"
     const val CONDA__NAME = "name"

--- a/script-server/src/test/kotlin/org/geobon/pipeline/YMLStepTest.kt
+++ b/script-server/src/test/kotlin/org/geobon/pipeline/YMLStepTest.kt
@@ -88,4 +88,14 @@ internal class YMLStepTest {
         assertNotNull(step.outputs["tell_me"])
         assertEquals("text/plain", step.outputs["tell_me"]!!.type)
     }
+
+    @Test
+    fun givenTextInput_whenReceivingOptionsInput_thenConversionAccepted() {
+        val correctInput = mockk<Pipe>()
+        every { correctInput.type } returns "options"
+        every { correctInput.validateGraph() } returns ""
+        val step = ResourceYml("scripts/assertText.yml", mutableMapOf("input" to correctInput))
+
+        assertTrue(step.validateGraph().isEmpty())
+    }
 }


### PR DESCRIPTION
With this feature, we can now plug an output of type option into an input of type text without validation error.

closes #334 

While working on this issue, I found #337, which is not resolved here. This means that int options need to be quoted, eg `"2000"` and not `2000`.