### PR TITLE
Location chooser and input form display

### DIFF
--- a/ui/src/components/PipelineEditor/Editor.css
+++ b/ui/src/components/PipelineEditor/Editor.css
@@ -140,6 +140,10 @@
   border-width: 5px;
 }
 
+.constant textarea {
+  position: relative;
+}
+
 .MuiGrid-root {
   background: none;
 }
@@ -413,7 +417,7 @@
 .collapseButton,
 .expandButton {
   height: 2rem;
-  z-index: 1000;
+  z-index: 1000; /* Collapse/expand button in IO pane */
   position: absolute;
   top: 5px;
   right: 10px;

--- a/ui/src/components/form/Choosers/CRSDescription.jsx
+++ b/ui/src/components/form/Choosers/CRSDescription.jsx
@@ -1,0 +1,33 @@
+import { useState } from "react"
+import yaml from "js-yaml";
+
+export default function CRSDescription({ bboxCRS }) {
+    const [viewSource, setViewSource] = useState(false);
+
+    if(viewSource) {
+        return <div>
+            <pre style={{ maxWidth: "330px", overflowX: "scroll" }}>
+                {yaml.dump(bboxCRS)}
+            </pre>
+            <a className="textButton" onClick={() => setViewSource(false)} style={{fontSize: "0.9em"}}>
+                Hide Source
+            </a>
+        </div>
+    }
+    return <div>
+        <p><strong>Country:</strong> {bboxCRS.country?.englishName}</p>
+        <p><strong>Region:</strong> {bboxCRS.region?.regionName}</p>
+        <p><strong>CRS:</strong> {bboxCRS.CRS?.name} (EPSG:{bboxCRS.CRS?.code})</p>
+        <p><strong>Bounding box:</strong></p>
+        <ul>
+            <li>West: {bboxCRS.bbox[0]}</li>
+            <li>South: {bboxCRS.bbox[1]}</li>
+            <li>East: {bboxCRS.bbox[2]}</li>
+            <li>North: {bboxCRS.bbox[3]}</li>
+        </ul>
+
+        <a className="textButton" onClick={() => setViewSource(true)} style={{fontSize: "0.9em"}}>
+            View Source
+        </a>
+    </div>
+}

--- a/ui/src/components/form/Choosers/CRSDescription.jsx
+++ b/ui/src/components/form/Choosers/CRSDescription.jsx
@@ -19,7 +19,7 @@ export default function CRSDescription({ bboxCRS }) {
         <p><strong>Region:</strong> {bboxCRS.region?.regionName}</p>
         <p><strong>CRS:</strong> {bboxCRS.CRS?.name} (EPSG:{bboxCRS.CRS?.code})</p>
         <p><strong>Bounding box:</strong></p>
-        <ul style={{fontFamily: "monospace"}}>
+        <ul style={{fontFamily: "monospace", listStyle: "none", paddingLeft: "1rem"}}>
             <li>Minimum X: {bboxCRS.bbox[0]}</li>
             <li>Minimum Y: {bboxCRS.bbox[1]}</li>
             <li>Maximum X: {bboxCRS.bbox[2]}</li>

--- a/ui/src/components/form/Choosers/CRSDescription.jsx
+++ b/ui/src/components/form/Choosers/CRSDescription.jsx
@@ -19,7 +19,7 @@ export default function CRSDescription({ bboxCRS }) {
         <p><strong>Region:</strong> {bboxCRS.region?.regionName}</p>
         <p><strong>CRS:</strong> {bboxCRS.CRS?.name} (EPSG:{bboxCRS.CRS?.code})</p>
         <p><strong>Bounding box:</strong></p>
-        <ul>
+        <ul style={{fontFamily: "monospace"}}>
             <li>Minimum X: {bboxCRS.bbox[0]}</li>
             <li>Minimum Y: {bboxCRS.bbox[1]}</li>
             <li>Maximum X: {bboxCRS.bbox[2]}</li>

--- a/ui/src/components/form/Choosers/CRSDescription.jsx
+++ b/ui/src/components/form/Choosers/CRSDescription.jsx
@@ -20,10 +20,10 @@ export default function CRSDescription({ bboxCRS }) {
         <p><strong>CRS:</strong> {bboxCRS.CRS?.name} (EPSG:{bboxCRS.CRS?.code})</p>
         <p><strong>Bounding box:</strong></p>
         <ul>
-            <li>West: {bboxCRS.bbox[0]}</li>
-            <li>South: {bboxCRS.bbox[1]}</li>
-            <li>East: {bboxCRS.bbox[2]}</li>
-            <li>North: {bboxCRS.bbox[3]}</li>
+            <li>Minimum X: {bboxCRS.bbox[0]}</li>
+            <li>Minimum Y: {bboxCRS.bbox[1]}</li>
+            <li>Maximum X: {bboxCRS.bbox[2]}</li>
+            <li>Maximum Y: {bboxCRS.bbox[3]}</li>
         </ul>
 
         <a className="textButton" onClick={() => setViewSource(true)} style={{fontSize: "0.9em"}}>

--- a/ui/src/components/form/Choosers/index.jsx
+++ b/ui/src/components/form/Choosers/index.jsx
@@ -76,7 +76,6 @@ export default function Choosers({
                     key={`choosers-modal-${inputId}`}
                     {...{
                       setOpenModal,
-                      inputId,
                       inputDescription,
                       value,
                       updateValue,
@@ -95,7 +94,6 @@ export default function Choosers({
               key={`choosers-modal-${inputId}`}
               {...{
                 setOpenModal,
-                inputId,
                 inputDescription,
                 value,
                 updateValue,
@@ -122,13 +120,11 @@ export default function Choosers({
   );
 }
 
-export function Chooser({
+function Chooser({
   setOpenModal,
-  inputId,
   inputDescription,
   value,
   updateValue = () => {},
-  onChange,
 }) {
   const [clearFeatures, setClearFeatures] = useState(0);
   const [digitize, setDigitize] = useState(false);

--- a/ui/src/components/form/Choosers/index.jsx
+++ b/ui/src/components/form/Choosers/index.jsx
@@ -32,16 +32,19 @@ export default function Choosers({
   const [openModal, setOpenModal] = useState(false);
 
   const type = inputDescription.type;
+
+  const label = leftLabel && inputDescription.label && (
+    <h4>
+      {inputDescription.label}
+    </h4>
+  )
+
   return (
     <>
       {type === "bboxCRS" && (
         <tr>
           <td className="inputCell">
-            {leftLabel && inputDescription.label && (
-              <h4 style={{color: "var(--biab-green-main)"}}>
-                {inputDescription.label}
-              </h4>
-            )}
+            {label}
             {value && !isCompact && <CRSDescription bboxCRS={value} />}
             <br />
           </td>
@@ -89,7 +92,8 @@ export default function Choosers({
       )}
       {type !== "bboxCRS" && (
         <tr>
-          <td>
+          <td className="inputCell">
+            {label}
             <Chooser
               key={`choosers-modal-${inputId}`}
               {...{

--- a/ui/src/components/form/Choosers/index.jsx
+++ b/ui/src/components/form/Choosers/index.jsx
@@ -6,7 +6,6 @@ const MapOpenLayers = lazy(() => import("./MapOpenLayers"));
 import CountryRegionMenu from "./CountryRegionMenu";
 import BBox from "./BBox";
 import CRSMenu from "./CRSMenu";
-import yaml from "js-yaml";
 import { CustomButtonGreen } from "../../CustomMUI";
 import ReactMarkdown from "react-markdown";
 import Alert from "@mui/material/Alert";
@@ -15,6 +14,7 @@ import CropFreeIcon from "@mui/icons-material/CropFree";
 import Modal from "@mui/material/Modal";
 import { chooserReducer } from "./chooserReducer";
 import { Spinner } from "../../Spinner";
+import CRSDescription from "./CRSDescription";
 
 export default function Choosers({
   inputId,
@@ -38,16 +38,11 @@ export default function Choosers({
         <tr>
           <td className="inputCell">
             {leftLabel && inputDescription.label && (
-              <>
-                <strong>{inputDescription.label}</strong>
-                {": "}
-              </>
+              <h4 style={{color: "var(--biab-green-main)"}}>
+                {inputDescription.label}
+              </h4>
             )}
-            {value && !isCompact && (
-              <pre style={{ maxWidth: "300px", overflowX: "scroll" }}>
-                {yaml.dump(value)}
-              </pre>
-            )}
+            {value && !isCompact && <CRSDescription bboxCRS={value} />}
             <br />
           </td>
           <td className="descriptionCell">
@@ -61,9 +56,11 @@ export default function Choosers({
                 setOpenModal(false);
               }}
               className="locationChooserButton"
+              style={{marginBottom: "1rem", fontSize: "1rem"}}
             >
               {`Choose ${inputDescription.label}`}
             </CustomButtonGreen>
+            <ReactMarkdown className="reactMarkdown">{inputDescription.description}</ReactMarkdown>
             <Modal
               key={`modal-chooser`}
               open={openModal}

--- a/ui/src/components/form/InputFileInputs.css
+++ b/ui/src/components/form/InputFileInputs.css
@@ -49,6 +49,14 @@ table.inputFileFields td.inputCell label {
   font-weight: 1000;
 }
 
+table.inputFileFields td.inputCell h4 {
+  margin-block-start: 0;
+  margin-block-end: 0.25em;
+  font-size: 1em;
+  font-weight: 1000;
+  color: #000c;
+}
+
 table.inputFileFields td.inputCell .MuiOutlinedInput-notchedOutline {
   border-color: var(--biab-green-trans-main);
 }

--- a/ui/src/components/form/InputFileInputs.css
+++ b/ui/src/components/form/InputFileInputs.css
@@ -42,10 +42,6 @@ table.inputFileFields td:last-child {
   border-top-right-radius: 10px;
 }
 
-table.inputFileFields td.inputCell {
-  color: var(--biab-green-main);
-}
-
 table.inputFileFields td.inputCell label {
   width: 100%;
   color: var(--biab-green-main);
@@ -166,3 +162,8 @@ table.inputFileFields .MuiInputBase-input {
   color: #333 !important;
 }
 
+.textButton {
+  cursor: pointer;
+  color: var(--biab-green-main);
+  font-weight: normal;
+}

--- a/ui/src/components/form/InputFileInputs.css
+++ b/ui/src/components/form/InputFileInputs.css
@@ -73,6 +73,16 @@ table.inputFileFields .example {
   background-color: transparent;
 }
 
+.textareaLabel {
+    position: absolute;
+    font-size: 0.8rem;
+    margin-top: -0.5rem;
+    margin-left: 10px;
+    background-color: white;
+    width: fit-content !important;
+    padding: 0px 5px;
+}
+
 table.inputFileFields textarea.autoResizeHeight {
   max-width: 300px;
   width: 100%;

--- a/ui/src/components/form/InputFileInputs.css
+++ b/ui/src/components/form/InputFileInputs.css
@@ -51,10 +51,10 @@ table.inputFileFields td.inputCell label {
 
 table.inputFileFields td.inputCell h4 {
   margin-block-start: 0;
-  margin-block-end: 0.25em;
+  margin-block-end: 1em;
   font-size: 1em;
   font-weight: 1000;
-  color: #000c;
+  color: var(--biab-green-main);
 }
 
 table.inputFileFields td.inputCell .MuiOutlinedInput-notchedOutline {

--- a/ui/src/components/form/ScriptInput.jsx
+++ b/ui/src/components/form/ScriptInput.jsx
@@ -267,12 +267,15 @@ export default function ScriptInput({
       if (stringValue.includes("\n")) {
         props.onKeyDown = (e) => e.ctrlKey && updateValue(e);
         return (
-          <AutoResizeTextArea
-            size={size}
-            cols={cols}
-            keepWidth={keepWidth}
-            {...props}
-          />
+          <>
+            {!small && <label for={props.id}>{label}</label>}
+            <AutoResizeTextArea
+              size={size}
+              cols={cols}
+              keepWidth={keepWidth}
+              {...props}
+            />
+          </>
         );
       } else {
         return (

--- a/ui/src/components/form/ScriptInput.jsx
+++ b/ui/src/components/form/ScriptInput.jsx
@@ -264,33 +264,33 @@ export default function ScriptInput({
         ...passedProps,
       };
 
-      if (stringValue.includes("\n")) {
-        props.onKeyDown = (e) => e.ctrlKey && updateValue(e);
-        return (
-          <>
-            {!small && <label className="textareaLabel" for={props.id}>{label}</label>}
-            <AutoResizeTextArea
-              size={size}
-              cols={cols}
-              keepWidth={keepWidth}
-              {...props}
-            />
-          </>
-        );
-      } else {
-        return (
-          <TextField
-            type="text"
-            label={label}
-            size={size}
-            {...props}
-            onKeyDown={(e) => {
-              if (e.key === "Enter" || e.ctrlKey) updateValue(e);
-            }}
-            slotProps={{ htmlInput: { style: small ? smallPadding() : null } }}
-            sx={{ width: "100%", maxWidth: small ? 220 : 328 }}
-          />
-        );
+      // Single line text fields
+      if (type.includes("/") /* assume MIME type, files have no line breaks */) {
+        return <TextField
+          type="text"
+          label={label}
+          size={size}
+          {...props}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.ctrlKey) updateValue(e);
+          }}
+          slotProps={{ htmlInput: { style: small ? smallPadding() : null } }}
+          sx={{ width: "100%", maxWidth: small ? 220 : 328 }}
+        />
       }
-  }
+
+      // Multiline text field
+      props.onKeyDown = (e) => e.ctrlKey && updateValue(e);
+      return (
+        <>
+          {!small && <label className="textareaLabel" for={props.id}>{label}</label>}
+          <AutoResizeTextArea
+            size={size}
+            cols={cols}
+            keepWidth={keepWidth}
+            {...props}
+          />
+        </>
+      );
+  }Z
 }

--- a/ui/src/components/form/ScriptInput.jsx
+++ b/ui/src/components/form/ScriptInput.jsx
@@ -292,5 +292,5 @@ export default function ScriptInput({
           />
         </>
       );
-  }Z
+  }
 }

--- a/ui/src/components/form/ScriptInput.jsx
+++ b/ui/src/components/form/ScriptInput.jsx
@@ -264,33 +264,19 @@ export default function ScriptInput({
         ...passedProps,
       };
 
-      if (stringValue.includes("\n")) {
-        props.onKeyDown = (e) => e.ctrlKey && updateValue(e);
-        return (
-          <>
-            {!small && <label className="textareaLabel" for={props.id}>{label}</label>}
-            <AutoResizeTextArea
-              size={size}
-              cols={cols}
-              keepWidth={keepWidth}
-              {...props}
-            />
-          </>
-        );
-      } else {
-        return (
-          <TextField
-            type="text"
-            label={label}
+
+      // Display input as string
+      props.onKeyDown = (e) => e.ctrlKey && updateValue(e);
+      return (
+        <>
+          {!small && <label className="textareaLabel" for={props.id}>{label}</label>}
+          <AutoResizeTextArea
             size={size}
+            cols={cols}
+            keepWidth={keepWidth}
             {...props}
-            onKeyDown={(e) => {
-              if (e.key === "Enter" || e.ctrlKey) updateValue(e);
-            }}
-            slotProps={{ htmlInput: { style: small ? smallPadding() : null } }}
-            sx={{ width: "100%", maxWidth: small ? 220 : 328 }}
           />
-        );
-      }
+        </>
+      );
   }
 }

--- a/ui/src/components/form/ScriptInput.jsx
+++ b/ui/src/components/form/ScriptInput.jsx
@@ -268,7 +268,7 @@ export default function ScriptInput({
         props.onKeyDown = (e) => e.ctrlKey && updateValue(e);
         return (
           <>
-            {!small && <label for={props.id}>{label}</label>}
+            {!small && <label className="textareaLabel" for={props.id}>{label}</label>}
             <AutoResizeTextArea
               size={size}
               cols={cols}

--- a/ui/src/components/form/ScriptInput.jsx
+++ b/ui/src/components/form/ScriptInput.jsx
@@ -264,19 +264,33 @@ export default function ScriptInput({
         ...passedProps,
       };
 
-
-      // Display input as string
-      props.onKeyDown = (e) => e.ctrlKey && updateValue(e);
-      return (
-        <>
-          {!small && <label className="textareaLabel" for={props.id}>{label}</label>}
-          <AutoResizeTextArea
+      if (stringValue.includes("\n")) {
+        props.onKeyDown = (e) => e.ctrlKey && updateValue(e);
+        return (
+          <>
+            {!small && <label className="textareaLabel" for={props.id}>{label}</label>}
+            <AutoResizeTextArea
+              size={size}
+              cols={cols}
+              keepWidth={keepWidth}
+              {...props}
+            />
+          </>
+        );
+      } else {
+        return (
+          <TextField
+            type="text"
+            label={label}
             size={size}
-            cols={cols}
-            keepWidth={keepWidth}
             {...props}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.ctrlKey) updateValue(e);
+            }}
+            slotProps={{ htmlInput: { style: small ? smallPadding() : null } }}
+            sx={{ width: "100%", maxWidth: small ? 220 : 328 }}
           />
-        </>
-      );
+        );
+      }
   }
 }


### PR DESCRIPTION
This pull request:
- Adds the label to all location choosers in the run UI form, as well as textAreas.
- Add the description to the BBoxCRS chooser, closes #341 
- Add a preview to the BBoxCRS chooser, which can expand into full yaml.
- Uses the resizable textarea type text, single line for files.

PS.: I did not remove the exception for the chooser pop up and bring the button back to the left. Maybe later.