### PR TITLE
View examples from /scripts folder

### DIFF
--- a/.github/workflows/docker_ui.yml
+++ b/.github/workflows/docker_ui.yml
@@ -11,6 +11,7 @@ on:
       - "viewer/**"
       - "Dockerfile.gateway.prod"
       - ".github/workflows/docker_ui.yml"
+      - "http-proxy/**"
 
 env:
   REGISTRY: ghcr.io

--- a/compose.yml
+++ b/compose.yml
@@ -88,6 +88,7 @@ services:
       - /var/run/docker.sock:/tmp/docker.sock:ro
       - ${PIPELINE_REPO_PATH}/output:/static/output:ro
       - ${PIPELINE_REPO_PATH}/userdata:/static/userdata:ro
+      - ${PIPELINE_REPO_PATH}/scripts:/static/scripts:ro
     depends_on:
       - script-server
       - python-api

--- a/http-proxy/conf.d-prod/ngnix.conf
+++ b/http-proxy/conf.d-prod/ngnix.conf
@@ -14,6 +14,11 @@ server {
         add_header Access-Control-Allow-Origin *;
     }
 
+     location /scripts/ {
+        root /static/;
+        add_header Access-Control-Allow-Origin *;
+    }
+
     location /pipeline/ {
         proxy_pass http://biab-script-server:8080/pipeline/;
         add_header Access-Control-Allow-Origin *;

--- a/http-proxy/conf.d-prod/ngnix.conf
+++ b/http-proxy/conf.d-prod/ngnix.conf
@@ -14,7 +14,7 @@ server {
         add_header Access-Control-Allow-Origin *;
     }
 
-     location /scripts/ {
+    location /scripts/ {
         root /static/;
         add_header Access-Control-Allow-Origin *;
     }

--- a/http-proxy/conf.d/ngnix.conf
+++ b/http-proxy/conf.d/ngnix.conf
@@ -14,6 +14,11 @@ server {
         add_header Access-Control-Allow-Origin *;
     }
 
+    location /scripts/ {
+        root /static/;
+        add_header Access-Control-Allow-Origin *;
+    }
+
     location /pipeline/ {
         proxy_pass http://biab-script-server:8080/pipeline/;
         add_header Access-Control-Allow-Origin *;


### PR DESCRIPTION
Currently, we are not able to view examples from the /scripts folder (issue #93). This pull request is meant to fix that and we have tested that the changes are working under the dev server, now we just want to see if it also works in the prod repo