### PR TITLE
Change ctrl+a behaviour in logs to select only the current logs.

### DIFF
--- a/ui/src/Layout.css
+++ b/ui/src/Layout.css
@@ -610,6 +610,7 @@ input[type="number"].input-float {
 
 .logs {
   border: 2px solid #87cefa45;
+  outline: none;
   height: 30em;
   overflow: auto;
   padding: 0.5em;

--- a/ui/src/components/LogViewer.jsx
+++ b/ui/src/components/LogViewer.jsx
@@ -63,18 +63,14 @@ export function LogViewer({ address, autoUpdate }) {
 
   return logs && <pre
     // Make ctrl + a select the logs only, not the whole page,
-    contenteditable="true"
-    spellcheck="false"
+    contentEditable="true"
+    suppressContentEditableWarning={true}
+    spellCheck="false"
     ref={logsRef}
     className='logs'
-    onInput={(e) => {
-      // but prevent user from editing the logs
+    onBeforeInput={(e) => {
+      // Prevent user from editing the logs (including copy-paste)
       e.preventDefault();
-
-      // and update the logs content to the original logs (without user edits)
-      if (logsRef.current) {
-        logsRef.current.textContent = logs;
-      }
     }}
   >
     {logs}<span ref={logsEndRef} />

--- a/ui/src/components/LogViewer.jsx
+++ b/ui/src/components/LogViewer.jsx
@@ -61,5 +61,17 @@ export function LogViewer({ address, autoUpdate }) {
     }
   }, [logs, logsAutoScroll]);
 
-  return logs && <pre ref={logsRef} className='logs'>{logs}<span ref={logsEndRef} /></pre>;
+  return logs && <pre
+    // Make ctrl + a select the logs only, not the whole page,
+    contenteditable="true"
+    spellcheck="false"
+    ref={logsRef}
+    className='logs'
+    beforeinput={(e) => {
+      // but prevent user from editing the logs
+      e.preventDefault();
+    }}
+  >
+    {logs}<span ref={logsEndRef} />
+  </pre>;
 }

--- a/ui/src/components/LogViewer.jsx
+++ b/ui/src/components/LogViewer.jsx
@@ -67,9 +67,14 @@ export function LogViewer({ address, autoUpdate }) {
     spellcheck="false"
     ref={logsRef}
     className='logs'
-    beforeinput={(e) => {
+    onInput={(e) => {
       // but prevent user from editing the logs
       e.preventDefault();
+
+      // and update the logs content to the original logs (without user edits)
+      if (logsRef.current) {
+        logsRef.current.textContent = logs;
+      }
     }}
   >
     {logs}<span ref={logsEndRef} />

--- a/ui/src/components/LogViewer.jsx
+++ b/ui/src/components/LogViewer.jsx
@@ -68,9 +68,19 @@ export function LogViewer({ address, autoUpdate }) {
     spellCheck="false"
     ref={logsRef}
     className='logs'
-    onBeforeInput={(e) => {
-      // Prevent user from editing the logs (including copy-paste)
+    onBeforeInput={e => e.preventDefault()} // This prevents typing letters normally
+    onPasteCapture={e => e.preventDefault()} // Prevents paste
+    onCutCapture={e => { // Copy to clipboard instead of cut
       e.preventDefault();
+      const selection = window.getSelection();
+      const range = selection.getRangeAt(0);
+      const selectedText = range.toString();
+      navigator.clipboard.writeText(selectedText);
+    }}
+    onKeyDownCapture={e => { // Prevent delete and backspace
+      if (e.key === "Backspace" || e.key === "Delete") {
+        e.preventDefault();
+      }
     }}
   >
     {logs}<span ref={logsEndRef} />


### PR DESCRIPTION
Change ctrl+a behaviour in logs to select only the current logs.

Previously it selected the whole page.