### PR TITLE
Add a filter to remove "undefined" (ie. null) outputs from the results viewer

### DIFF
--- a/viewer/src/components/Sidebar/index.tsx
+++ b/viewer/src/components/Sidebar/index.tsx
@@ -221,7 +221,9 @@ export default function Sidebar(props: any) {
           return a.weight - b.weight;
         });
       }
-      sortable.map((pd: any) => {
+      sortable
+      .filter((pd: any) => pd.outputs !== "undefined")
+      .map((pd: any) => {
         if (pd) {
           return pips.push(
             <PipelineOutput

--- a/viewer/src/components/Sidebar/index.tsx
+++ b/viewer/src/components/Sidebar/index.tsx
@@ -222,7 +222,7 @@ export default function Sidebar(props: any) {
         });
       }
       sortable
-      .filter((pd: any) => pd.outputs !== "undefined")
+      .filter((pd: any) => pd.outputs !== "undefined" && pd.outputs !== undefined && pd.outputs !== null)
       .map((pd: any) => {
         if (pd) {
           return pips.push(

--- a/viewer/src/helpers/biab_api.tsx
+++ b/viewer/src/helpers/biab_api.tsx
@@ -79,11 +79,11 @@ export const createPipeline4Display = async (pipeline_run_id: string) => {
           const output = getScriptOutput(p);
           if (script in pro) {
             const script_run_output_path = pro[script];
-            return await GetScriptOutputs(script_run_output_path).then(
+            return await GetScriptOutputs(script_run_output_path).then( // TODO: Should not call GetScriptOutputs multiple times, use scriptDescriptionStore from the "ui" folder
               (out: any) => {
                 return {
                   ...po.outputs[p],
-                  outputs: `${out[output]}`,
+                  outputs: `${out[output]}`, // TODO should be out[output] && `${out[output]}` to avoid having "undefined" strings
                 };
               }
             );


### PR DESCRIPTION
temporarily addresses #379, but does not fully fix it.