### PR TITLE
[Pipeline editor] Bring back double-click for constants and outputs

### DIFF
--- a/ui/src/components/PipelineEditor/IONode.jsx
+++ b/ui/src/components/PipelineEditor/IONode.jsx
@@ -91,13 +91,15 @@ export default function IONode({ id, data }) {
   }
 
   return <>
-  <table className={`ioNode ${stepType}`} onDoubleClick={() =>
+  <table className={`ioNode ${stepType}`} onDoubleClick={(e) => {
+    if (e.target.closest('td.inputs, td.outputs')) return;
     setPopupContent(
       <StepDescription
         descriptionFile={descriptionFileLocation}
         metadata={metadata}
       />
-  )}>
+    )}
+  }>
     <tbody>
     <tr>
       <td className='inputs'>


### PR DESCRIPTION
Double click function back to normal: double click on script/pipeline triggers the popup metadata, double click on inputs/outputs creates the input/output box.

Close #414 