### PR TITLE
Stop collapsing input form when pipeline or script is run

### DIFF
--- a/ui/src/components/PipelinePage.jsx
+++ b/ui/src/components/PipelinePage.jsx
@@ -270,7 +270,7 @@ export function PipelinePage({ runType }) {
       // scrolling immediately targets a position that's stale by the time
       // those animations finish. Wait for the section's position to settle
       // before scrolling to it.
-      let rafId;
+      let frameRequestId; // valid for a single frame
       let lastTop = null;
       let stableFrames = 0;
       const waitForStableLayout = () => {
@@ -281,15 +281,16 @@ export function PipelinePage({ runType }) {
           stableFrames = 0;
           lastTop = top;
         }
+        
         if (stableFrames >= 5) {
           resultsRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
         } else {
-          rafId = requestAnimationFrame(waitForStableLayout);
+          frameRequestId = requestAnimationFrame(waitForStableLayout);
         }
       };
-      rafId = requestAnimationFrame(waitForStableLayout);
+      frameRequestId = requestAnimationFrame(waitForStableLayout);
       hadResultsRef.current = true;
-      return () => cancelAnimationFrame(rafId);
+      return () => cancelAnimationFrame(frameRequestId);
     }
     hadResultsRef.current = resultsData != null;
   }, [resultsData])

--- a/ui/src/components/PipelinePage.jsx
+++ b/ui/src/components/PipelinePage.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useReducer, useCallback } from "react";
+import React, { useState, useEffect, useReducer, useCallback, useRef } from "react";
 
 import { PipelineForm } from "./form/PipelineForm";
 import { useParams } from "react-router-dom";
@@ -90,6 +90,8 @@ export function PipelinePage({ runType }) {
   const [httpError, setHttpError] = useState(null);
   const [pipelineMetadata, setPipelineMetadata] = useState(null);
   const [expandInputs, setExpandInputs] = useState(true);
+
+  const resultsRef = useRef(null);
 
   /**
    * String: Content of input.json for this run
@@ -258,11 +260,39 @@ export function PipelinePage({ runType }) {
     });
   };
 
-  useEffect(()=>{
-    if(pipStates.runHash){
-      setExpandInputs(false)
+
+  const hadResultsRef = useRef(false);
+  useEffect(() => {
+    if (resultsData != null && !hadResultsRef.current) {
+      // The accordion collapse (triggered above) and PipelineResults' own
+      // auto-expand-first-output scroll (FoldableOutput.jsx) both keep moving
+      // the layout above the results section for a bit after it mounts, so
+      // scrolling immediately targets a position that's stale by the time
+      // those animations finish. Wait for the section's position to settle
+      // before scrolling to it.
+      let rafId;
+      let lastTop = null;
+      let stableFrames = 0;
+      const waitForStableLayout = () => {
+        const top = resultsRef.current?.getBoundingClientRect().top;
+        if (top === lastTop) {
+          stableFrames++;
+        } else {
+          stableFrames = 0;
+          lastTop = top;
+        }
+        if (stableFrames >= 5) {
+          resultsRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+        } else {
+          rafId = requestAnimationFrame(waitForStableLayout);
+        }
+      };
+      rafId = requestAnimationFrame(waitForStableLayout);
+      hadResultsRef.current = true;
+      return () => cancelAnimationFrame(rafId);
     }
-  },[pipStates.runHash])
+    hadResultsRef.current = resultsData != null;
+  }, [resultsData])
 
   const toggleAccord  = useCallback(() => {
     setExpandInputs(prev => !prev);
@@ -318,18 +348,20 @@ export function PipelinePage({ runType }) {
           </div>
         )}
         {pipelineMetadata && (
-          <PipelineResults
-            key="results"
-            pipelineMetadata={pipelineMetadata}
-            inputFileContent={inputFileContent}
-            resultsData={resultsData}
-            runningScripts={runningScripts}
-            setRunningScripts={setRunningScripts}
-            pipeline={pipeline}
-            runHash={runHash}
-            displayTimeStamp={pipStates.timestamp}
-            isPipeline={runType === "pipeline"}
-          />
+          <div ref={resultsRef}>
+            <PipelineResults
+              key="results"
+              pipelineMetadata={pipelineMetadata}
+              inputFileContent={inputFileContent}
+              resultsData={resultsData}
+              runningScripts={runningScripts}
+              setRunningScripts={setRunningScripts}
+              pipeline={pipeline}
+              runHash={runHash}
+              displayTimeStamp={pipStates.timestamp}
+              isPipeline={runType === "pipeline"}
+            />
+          </div>
         )}
       </div>
     </>


### PR DESCRIPTION
Instead of collapsing the input form, the window is scrolled to the results section instead. 