### PR TITLE
Double mem on OOM failure up to value set by new mem-max key

### DIFF
--- a/.github/scriptValidationSchema.yml
+++ b/.github/scriptValidationSchema.yml
@@ -217,6 +217,10 @@ compute:
       required: true
       type: string
       regex: "^[0-9]+[GM]$"
+    mem-max:
+      required: false
+      type: string
+      regex: "^[0-9]+[GM]$"
     cpus-per-task:
       required: true
       type: integer

--- a/docs_source/how_to_contribute.qmd
+++ b/docs_source/how_to_contribute.qmd
@@ -393,7 +393,8 @@ conda: # Optional, only needed if you need packages not in the central environme
     - r-terra
 compute: # Optional, specify compute requirements for kubernetes or HPC clusters. If absent, default values apply.
   hpc: false # Optional, send to a HPC cluster if available. Defaults to false.
-  mem: 4Gi # Hard cap for the memory usage, default 4Gi.
+  mem: 4Gi # Cap for the memory usage, default 4Gi.
+  mem-max: 64Gi # Optional, if the job fails, the job's available memory will be increased up to this value. 
   cpus-per-task: 4 # Number of CPU  allocated, default 4.
   time: "02:00:00" # Only when "hpc: true", maximum time allowed before the job is interrupted.
 ```

--- a/script-server/src/main/kotlin/org/geobon/k8s/K8sConnection.kt
+++ b/script-server/src/main/kotlin/org/geobon/k8s/K8sConnection.kt
@@ -335,6 +335,22 @@ class K8sConnection {
 			)
 	}
 
+	/** True if any pod belonging to this job was killed by the kernel OOM killer. */
+	fun wasOOMKilled(namespace: String, jobName: String): Boolean {
+		return runCatching {
+			createCoreApi().listNamespacedPod(namespace)
+				.labelSelector("job-name=$jobName")
+				.execute()
+				.items
+				.any { pod ->
+					pod.status?.containerStatuses.orEmpty().any { status ->
+						status.state?.terminated?.reason == "OOMKilled"
+								|| status.lastState?.terminated?.reason == "OOMKilled"
+					}
+				}
+		}.getOrDefault(false)
+	}
+
 	fun describeJobPods(namespace: String, jobName: String) : String {
 		return runCatching {
 			val pods = createCoreApi().listNamespacedPod(namespace)

--- a/script-server/src/main/kotlin/org/geobon/k8s/KubernetesRun.kt
+++ b/script-server/src/main/kotlin/org/geobon/k8s/KubernetesRun.kt
@@ -20,6 +20,10 @@ import kotlin.time.Duration.Companion.seconds
 import kotlin.time.ExperimentalTime
 import kotlin.time.TimeSource
 
+/** Thrown when a Kubernetes job's pod was killed by the kernel OOM killer, so [KubernetesRun] can retry with more memory. */
+private class OomKilledException(jobName: String) :
+    RuntimeException("Kubernetes job '$jobName' was killed by the OOM killer.")
+
 class KubernetesRun(
     context: RunContext,
     scriptFile: File,
@@ -52,42 +56,55 @@ class KubernetesRun(
         val jobName = toJobName(context.runId)
 
         runCatching {
-            val command = buildScriptCommand(scriptType)
-            val job = connection.buildJob(jobName, command, scriptType, computeRequirements)
             val api = connection.createBatchApi()
             val coreApi = connection.createCoreApi()
 
-            // Use cached result if the job already succeeded; otherwise replace stale runs.
-            val jobAlreadySucceeded = try {
-                val existingStatus = api.readNamespacedJobStatus(jobName, namespace).execute().status
-                if ((existingStatus?.succeeded ?: 0) > 0) {
-                    log(logger::info, "Kubernetes job '$jobName' already succeeded, using cached result.")
-                    true
-                } else {
-                    log(logger::debug, "Found pre-existing failed Kubernetes job.")
-                    deleteJobAndWait(
-                        api = api,
-                        coreApi = coreApi,
-                        namespace = namespace,
-                        jobName = jobName,
-                        waitForOutput = false
-                    )
+            // Bumped up to computeRequirements.memMax (when set) each time a run is OOM-killed.
+            var currentRequirements = computeRequirements
+            while (true) {
+                val command = buildScriptCommand(scriptType)
+                val job = connection.buildJob(jobName, command, scriptType, currentRequirements)
+
+                // Use cached result if the job already succeeded; otherwise replace stale runs.
+                val jobAlreadySucceeded = try {
+                    val existingStatus = api.readNamespacedJobStatus(jobName, namespace).execute().status
+                    if ((existingStatus?.succeeded ?: 0) > 0) {
+                        log(logger::info, "Kubernetes job '$jobName' already succeeded, using cached result.")
+                        true
+                    } else {
+                        log(logger::debug, "Found pre-existing failed Kubernetes job.")
+                        deleteJobAndWait(
+                            api = api,
+                            coreApi = coreApi,
+                            namespace = namespace,
+                            jobName = jobName,
+                            waitForOutput = false
+                        )
+                        false
+                    }
+                } catch (ex: ApiException) {
+                    if (ex.code != 404) throw ex
                     false
                 }
-            } catch (ex: ApiException) {
-                if (ex.code != 404) throw ex
-                false
-            }
 
-            if (!jobAlreadySucceeded) {
-                log(logger::info, "Submitting job '$jobName' in namespace '$namespace'...")
+                if (jobAlreadySucceeded) break
+
+                log(logger::info, "Submitting job '$jobName' in namespace '$namespace' (mem=${currentRequirements?.mem ?: "default"})...")
                 val created = api.createNamespacedJob(namespace, job).execute()
                 log(
                     logger::debug,
                     "Job created, uid='${created.metadata?.uid}'."
                 )
 
-                waitForJobCompletion(api, coreApi, namespace, jobName, timeout)
+                try {
+                    waitForJobCompletion(api, coreApi, namespace, jobName, timeout)
+                    break
+                } catch (ex: OomKilledException) {
+                    val bumped = currentRequirements?.bumpMemOrNull()
+                        ?: throw ex
+                    log(logger::warn, "Job '$jobName' was OOM-killed; retrying with mem=${bumped.mem} (max ${bumped.memMax}).")
+                    currentRequirements = bumped
+                }
             }
 
             if (resultFile.exists()) {
@@ -115,6 +132,10 @@ class KubernetesRun(
                     val event = ex.message ?: ex.javaClass.name
                     log(logger::info, "$event: done.")
                     outputs[ERROR_KEY] = event
+                }
+
+                is OomKilledException -> {
+                    outputs[ERROR_KEY] = (ex.message ?: "Job was OOM-killed.").also { log(logger::warn, it) }
                 }
 
                 is ApiException -> {
@@ -182,6 +203,9 @@ class KubernetesRun(
                     }
 
                     if ((status?.failed ?: 0) > 0) {
+                        if (connection.wasOOMKilled(namespace, jobName)) {
+                            throw OomKilledException(jobName)
+                        }
                         throw RuntimeException("Kubernetes job '$jobName' failed.")
                     }
 

--- a/script-server/src/main/kotlin/org/geobon/pipeline/ScriptStep.kt
+++ b/script-server/src/main/kotlin/org/geobon/pipeline/ScriptStep.kt
@@ -93,7 +93,8 @@ open class ScriptStep : YMLStep {
                             ?: throw RuntimeException("compute ${Description.COMPUTE__MEMORY} parameter is not formatted as expected. \nExample: 30G \nGot: ${computeSection[Description.COMPUTE__MEMORY]}")
                         val cpus = computeSection[Description.COMPUTE__CPUS] as? Int
                             ?: throw RuntimeException("compute ${Description.COMPUTE__CPUS} parameter should be an int. Got: ${computeSection[Description.COMPUTE__CPUS]}")
-                        ComputeRequirements(mem, cpus)
+                        val memMax = computeSection[Description.COMPUTE__MEMORY_MAX] as? String
+                        ComputeRequirements(mem, cpus, memMax)
                     } else null
 
                     if (computeSection is Map<*, *> && computeSection[Description.COMPUTE__HPC] == true && shouldUseHPC()) {

--- a/script-server/src/main/kotlin/org/geobon/script/ComputeRequirements.kt
+++ b/script-server/src/main/kotlin/org/geobon/script/ComputeRequirements.kt
@@ -2,5 +2,36 @@ package org.geobon.script
 
 data class ComputeRequirements(
     val mem: String,
-    val cpus: Int
-)
+    val cpus: Int,
+    /** Optional ceiling for automatic memory bump on OOMKilled retries. No bump happens when null. */
+    val memMax: String? = null
+) {
+    /**
+     * Doubles [mem] (capped at [memMax]) for a retry after an OOMKilled failure.
+     * Returns null when no [memMax] is configured or [mem] has already reached it.
+     */
+    fun bumpMemOrNull(factor: Double = 2.0): ComputeRequirements? {
+        val maxBytes = memMax?.let(::parseMemBytes) ?: return null
+        val currentBytes = parseMemBytes(mem)
+        if (currentBytes >= maxBytes) return null
+
+        val bumpedBytes = (currentBytes * factor).toLong().coerceAtMost(maxBytes)
+        return copy(mem = formatMemBytes(bumpedBytes))
+    }
+
+    companion object {
+        private val MEM_PATTERN = Regex("^([0-9]+)([GM])$")
+
+        private fun parseMemBytes(mem: String): Long {
+            val (value, unit) = MEM_PATTERN.matchEntire(mem)?.destructured
+                ?: throw IllegalArgumentException("Invalid memory format: $mem. Expected e.g. \"30G\" or \"512M\".")
+            val multiplier = if (unit == "G") 1_000_000_000L else 1_000_000L
+            return value.toLong() * multiplier
+        }
+
+        private fun formatMemBytes(bytes: Long): String {
+            return if (bytes % 1_000_000_000L == 0L) "${bytes / 1_000_000_000L}G"
+            else "${(bytes + 999_999L) / 1_000_000L}M"
+        }
+    }
+}

--- a/script-server/src/main/kotlin/org/geobon/script/Description.kt
+++ b/script-server/src/main/kotlin/org/geobon/script/Description.kt
@@ -30,6 +30,7 @@ object Description {
     const val COMPUTE = "compute"
     const val COMPUTE__HPC = "hpc"
     const val COMPUTE__MEMORY = "mem"
+    const val COMPUTE__MEMORY_MAX = "mem-max"
     const val COMPUTE__CPUS = "cpus-per-task"
     const val COMPUTE__DURATION = "time"
 }


### PR DESCRIPTION
Proposed solution for https://github.com/GEO-BON/bon-in-a-box-pipeline-engine/issues/411

The idea is to double mem on OOM failure up to value set by new mem-max key. 

- compute: YAML block gains an optional mem-max field (same ^[0-9]+[GM]$ format as mem), validated in /.github/scriptValidationSchema.ym). Scripts that don't set it behave exactly as before.
- ComputeRequirements .kt carries memMax and a bumpMemOrNull() helper that doubles mem, capped at memMax, returning null once the ceiling is reached (so retries are bounded — no infinite loop).
- K8sConnection.wasOOMKilled() checks a job's pods for a container terminated with reason OOMKilled.
- KubernetesRun now loops: submit job → wait → if it was OOM-killed and a memMax is configured, bump mem and resubmit; otherwise fail as before, with a dedicated OomKilledException surfaced in the error output.`